### PR TITLE
(#1) add error and success handling

### DIFF
--- a/lib/puppet/datatypes/choria/taskresult.rb
+++ b/lib/puppet/datatypes/choria/taskresult.rb
@@ -7,6 +7,7 @@ Puppet::DataTypes.create_type("Choria::TaskResult") do
     functions => {
       error => Callable[[], Optional[Error]],
       ok => Callable[[], Boolean],
+      fail_ok => Callable[[], Boolean],
       type => Callable[[], String[1]],
       "[]" => Callable[[String[1]], Data]
     }

--- a/lib/puppet/datatypes/choria/taskresults.rb
+++ b/lib/puppet/datatypes/choria/taskresults.rb
@@ -2,6 +2,7 @@ Puppet::DataTypes.create_type("Choria::TaskResults") do
   interface <<-PUPPET
     attributes => {
       "results" => Array[Choria::TaskResult, 0],
+      "exception" => Optional[Error],
     },
     functions => {
       count => Callable[[], Integer],
@@ -11,7 +12,9 @@ Puppet::DataTypes.create_type("Choria::TaskResults") do
       first => Callable[[], Optional[Choria::TaskResult]],
       ok => Callable[[], Boolean],
       ok_set => Callable[[], Choria::TaskResults],
+      fail_ok => Callable[[], Boolean],
       hosts => Callable[[], Choria::Nodes],
+      message => Callable[[], String],
     }
   PUPPET
 

--- a/lib/puppet/functions/choria/on_error.rb
+++ b/lib/puppet/functions/choria/on_error.rb
@@ -1,0 +1,13 @@
+Puppet::Functions.create_function(:"choria::on_error", Puppet::Functions::InternalFunction) do
+  dispatch :handler do
+    param "Choria::TaskResults", :results
+    block_param
+    return_type "Choria::TaskResults"
+  end
+
+  def handler(results)
+    yield(results) if results.exception || !results.error_set.empty
+
+    results
+  end
+end

--- a/lib/puppet/functions/choria/on_success.rb
+++ b/lib/puppet/functions/choria/on_success.rb
@@ -1,0 +1,15 @@
+Puppet::Functions.create_function(:"choria::on_success", Puppet::Functions::InternalFunction) do
+  dispatch :handler do
+    param "Choria::TaskResults", :results
+    block_param
+    return_type "Choria::TaskResults"
+  end
+
+  def handler(results)
+    return results if !results.error_set.empty || results.exception
+
+    yield(results)
+
+    results
+  end
+end

--- a/lib/puppet/functions/choria/task.rb
+++ b/lib/puppet/functions/choria/task.rb
@@ -57,10 +57,6 @@ Puppet::Functions.create_function(:"choria::task", Puppet::Functions::InternalFu
   def run_task(scope, type, properties)
     require_relative "../../_load_choria"
 
-    results = MCollective::Util::BoltSupport.init_choria.run_task(scope, type, properties).map do |node, properties|
-      MCollective::Util::BoltSupport::TaskResult.new(node, properties)
-    end
-
-    MCollective::Util::BoltSupport::TaskResults.new(results)
+    MCollective::Util::BoltSupport.init_choria.run_task(scope, type, properties)
   end
 end


### PR DESCRIPTION
Plans that invoke other plans can now ignore exceptions from those
plans and use the on_error/on_success chainable methods to handle failures

```
  choria::run_playbook("acme::always_exception", _catch_errors => true)
    .choria::on_error |$results| {
      notice(sprintf("Failed with: %s", $results.message))
    }
    .choria::on_success |$results| {
      notice("passed")
    }
```