### PR TITLE
(#41) Always set the FQDN in the generated config file

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -47,6 +47,7 @@
 # @param client_port Port clients will connec tto
 # @param cluster_peer_port Port other brokers will connect to
 # @param stats_port Port where Prometheus stats are hosted
+# @param identity The identity this server will use to determine SSL cert names etc
 class choria::broker (
   Boolean $network_broker = true,
   Boolean $federation_broker = false,
@@ -59,7 +60,8 @@ class choria::broker (
   Array[String] $network_peers = [],
   Array[String] $federation_middleware_hosts = [],
   Array[String] $collective_middleware_hosts = [],
-  Choria::Adapters $adapters = {}
+  Choria::Adapters $adapters = {},
+  String $identity = $facts["networking"]["fqdn"]
 ) {
   require choria
 

--- a/spec/classes/broker/config_spec.rb
+++ b/spec/classes/broker/config_spec.rb
@@ -23,6 +23,28 @@ describe("choria::broker::config") do
 
   let(:pre_condition) { 'class {"choria": }' }
 
+  context("general settings") do
+    let(:pre_condition) { 'class {"choria::broker": }' }
+
+    it "should use the system fqdn for identity" do
+      is_expected.to contain_file("/etc/choria/broker.conf").with_content(/plugin.choria.srv_domain = rspec.example.net/)
+        .with_content(/logfile = \/var\/log\/choria.log/)
+        .with_content(/loglevel = warn/)
+        .with_content(/identity = choria1.rspec.example.net/)
+    end
+
+    context("custom identity") do
+      let(:pre_condition) { 'class {"choria::broker": identity => "custom.rspec.example.net"}' }
+
+      it "should use the supplied identity" do
+        is_expected.to contain_file("/etc/choria/broker.conf").with_content(/plugin.choria.srv_domain = rspec.example.net/)
+          .with_content(/logfile = \/var\/log\/choria.log/)
+          .with_content(/loglevel = warn/)
+          .with_content(/identity = custom.rspec.example.net/)
+      end
+    end
+  end
+
   context("without the network broker") do
     let(:pre_condition) { 'class {"choria::broker": network_broker => false}' }
 
@@ -32,12 +54,14 @@ describe("choria::broker::config") do
       is_expected.to contain_file("/etc/choria/broker.conf").with_content(/plugin.choria.srv_domain = rspec.example.net/)
         .with_content(/logfile = \/var\/log\/choria.log/)
         .with_content(/loglevel = warn/)
+        .with_content(/identity = choria1.rspec.example.net/)
         .with_content(/JSON information about this broker/)
         .without_content(/Embedded NATS general statistics/)
         .without_content(/plugin.choria.broker_network = true/)
         .without_content(/plugin.choria.network.peers/)
         .without_content(/plugin.choria.broker_federation/)
     end
+
   end
 
   context("standalone network broker") do

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -1,5 +1,6 @@
 logfile = <%= $choria::log_file %>
 loglevel = <%= $choria::log_level %>
+identity = <%= $choria::broker::identity %>
 
 <% if $choria::srvdomain { -%>
 plugin.choria.srv_domain = <%= $choria::srvdomain %>


### PR DESCRIPTION
Ubuntu/Debian configures their networking to to return hostname only
not FQDN like redhat does to the c library calls for obtaining the
hostname.

This is ancient bug we fixed in mcollective and might fix in go-choria
but for now, this will solve it for puppet users and has a smaller
change set/risk associated