### PR TITLE
(#45) Ensure the server service is off by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,10 @@
 # @param logfile The file to log to
 # @param loglevel The logging level to use
 # @param srvdomain The domain name to use when doing SRV lookups
+# @param package_name The package to install
+# @param broker_service_name The service name of the Choria Broker
+# @param server_service_name The service name of the Choria Server
+# @param server To enable or disable the choria server
 class choria (
   Boolean $manage_package_repo = false,
   Boolean $nightly_repo = false,
@@ -19,6 +23,8 @@ class choria (
   Stdlib::Compat::Absolute_path $log_file = "/var/log/choria.log",
   String $package_name = "choria",
   String $broker_service_name = "choria-broker",
+  String $server_service_name = "choria-server",
+  Boolean $server = false,
 ) {
   if $manage_package_repo {
     class{"choria::repo":
@@ -28,5 +34,10 @@ class choria (
     }
   }
 
+  class{"choria::install": }
+
+  -> class{"choria::service": }
+
   contain choria::install
+  contain choria::service
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,18 @@
+# Manages the `choria-server` service
+#
+# @private
+class choria::service {
+  assert_private()
+
+  if $choria::server {
+    service{$choria::server_service_name:
+      ensure => "running",
+      enable => true
+    }
+  } else {
+    service{$choria::server_service_name:
+      ensure => "stopped",
+      enable => false
+    }
+  }
+}

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe("choria::install") do
+  before(:each) do
+    Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) {|_| }
+  end
+
+  let(:facts) do
+    {
+      "aio_agent_version" => "1.7.0",
+      "os" => {
+        "family" => "RedHat"
+      }
+    }
+  end
+
+  context("when enabled") do
+    let(:pre_condition) { 'class {"choria": server => true}' }
+
+    it { should compile.with_all_deps }
+
+    it "should enable the service" do
+      is_expected.to contain_service("choria-server")
+        .with_ensure("running")
+        .with_enable(true)
+    end
+  end
+
+  context("by default") do
+    let(:pre_condition) { 'class {"choria": }' }
+
+    it { should compile.with_all_deps }
+
+    it "should disable the service" do
+      is_expected.to contain_service("choria-server")
+        .with_ensure("stopped")
+        .with_enable(false)
+    end
+  end
+end


### PR DESCRIPTION
At the moment we ship the server service and on debian like machines
enable it by default.  But this is a bit premature as it does not
yet do anything and only speaks JSON which we do not configure the
clients for right now

So this disables and stops the server service by default as there is not
even any config for it at present

There's a flag though to enable it should there be some weird need for
it