### PR TITLE
(#49) Fix on_error handling

### DIFF
--- a/lib/puppet/functions/choria/on_error.rb
+++ b/lib/puppet/functions/choria/on_error.rb
@@ -48,7 +48,7 @@ Puppet::Functions.create_function(:"choria::on_error", Puppet::Functions::Intern
   end
 
   def handler(results)
-    if results.is_a?(MCollective::Util::BoltSupport::TaskResults) && (results.exception || !results.error_set.empty)
+    if results.is_a?(MCollective::Util::BoltSupport::TaskResults) && results.error_set.empty && !results.exception
       yield(results)
     end
 


### PR DESCRIPTION
The on_error function was incorrectly checking the result set and
would not be called for some legit success cases