### PR TITLE
(#53) configure the choria server

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,45 @@
+---
+choria::server_config:
+  classesfile: "/opt/puppetlabs/puppet/cache/state/classes.txt"
+  plugin.rpcaudit.logfile: "/var/log/puppetlabs/mcollective-audit.log"
+  plugin.yaml: "/etc/puppetlabs/mcollective/generated-facts.yaml"
+  plugin.choria.agent_provider.mcorpc.agent_shim: "/usr/bin/choria_mcollective_agent_compat.rb"
+  plugin.choria.agent_provider.mcorpc.config: "/etc/puppetlabs/mcollective/server.cfg"
+  plugin.choria.agent_provider.mcorpc.libdir: "/opt/puppetlabs/mcollective/plugins"
+
+choria::rubypath: "/opt/puppetlabs/puppet/bin/ruby"
+choria::manage_package_repo: false
+choria::nightly_repo: false
+choria::ensure: "present"
+choria::version: "present"
+choria::log_level: "warn"
+choria::srvdomain: "%{facts.networking.domain}"
+choria::broker_config_file: "/etc/choria/broker.conf"
+choria::server_config_file: "/etc/choria/server.conf"
+choria::log_file: "/var/log/choria.log"
+choria::package_name: "choria"
+choria::broker_service_name: "choria-broker"
+choria::server_service_name: "choria-server"
+choria::identity: "%{trusted.certname}"
+choria::server: false
+
+choria::broker::network_broker: true
+choria::broker::federation_broker: false
+choria::broker::federation_cluster: "%{::environment}"
+choria::broker::listen_address: "::"
+choria::broker::stats_listen_address: "::"
+choria::broker::client_port: 4222
+choria::broker::cluster_peer_port: 4223
+choria::broker::stats_port: 8222
+choria::broker::network_peers: []
+choria::broker::federation_middleware_hosts: []
+choria::broker::collective_middleware_hosts: []
+choria::broker::adapters: {}
+choria::broker::identity: "%{trusted.certname}"
+
+lookup_options:
+  choria::collectives:
+    merge: "unique"
+  choria::server_config:
+    merge:
+      strategy: "deep"

--- a/functions/hash2config.pp
+++ b/functions/hash2config.pp
@@ -1,0 +1,8 @@
+# Generates configuration files for mcollective. Keys are sorted alphabetically:
+# key = value
+function choria::hash2config(Hash $confighash) >> String {
+  $result = $confighash.keys.sort.map |$key| {
+    sprintf("%s = %s", $key, $confighash[$key])
+  }
+  ($result << []).join("\n")
+}

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,12 @@
+---
+version: 5
+
+defaults:
+  datadir: "data"
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "OS family"
+    path: "os/%{facts.os.family}.yaml"
+  - name: "common"
+    path: "common.yaml"

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -47,21 +47,21 @@
 # @param client_port Port clients will connec tto
 # @param cluster_peer_port Port other brokers will connect to
 # @param stats_port Port where Prometheus stats are hosted
-# @param identity The identity this server will use to determine SSL cert names etc
+# @param identity The identity this broker will use to determine SSL cert names etc
 class choria::broker (
-  Boolean $network_broker = true,
-  Boolean $federation_broker = false,
-  Optional[String] $federation_cluster = $environment,
-  Stdlib::Compat::Ip_address $listen_address = "::",
-  Stdlib::Compat::Ip_address $stats_listen_address = "::",
-  Integer $client_port = 4222,
-  Integer $cluster_peer_port = 4223,
-  Integer $stats_port = 8222,
-  Array[String] $network_peers = [],
-  Array[String] $federation_middleware_hosts = [],
-  Array[String] $collective_middleware_hosts = [],
-  Choria::Adapters $adapters = {},
-  String $identity = $facts["networking"]["fqdn"]
+  Boolean $network_broker,
+  Boolean $federation_broker,
+  Optional[String] $federation_cluster,
+  Stdlib::Compat::Ip_address $listen_address,
+  Stdlib::Compat::Ip_address $stats_listen_address,
+  Integer $client_port,
+  Integer $cluster_peer_port,
+  Integer $stats_port,
+  Array[String] $network_peers,
+  Array[String] $federation_middleware_hosts,
+  Array[String] $collective_middleware_hosts,
+  Choria::Adapters $adapters,
+  String $identity
 ) {
   require choria
 

--- a/manifests/broker/config.pp
+++ b/manifests/broker/config.pp
@@ -4,7 +4,7 @@
 class choria::broker::config {
   assert_private()
 
-  file{$choria::broker_config:
+  file{$choria::broker_config_file:
     owner   => "root",
     group   => "root",
     mode    => "0640",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,36 @@
+# Configures the Choria Server
+#
+# @private
+class choria::config {
+  assert_private()
+
+  $defaults = {
+    "collectives" => "mcollective"
+  }
+
+  $config = $defaults + $choria::server_config + {
+    "logfile"                    => $choria::log_file,
+    "loglevel"                   => $choria::log_level,
+    "identity"                   => $choria::identity,
+    "plugin.choria.srv_domain"   => $choria::srvdomain,
+  }
+
+  if "plugin.choria.agent_provider.mcorpc.agent_shim" in $choria::server_config  and "plugin.choria.agent_provider.mcorpc.config" in $choria::server_config {
+    file{$choria::server_config["plugin.choria.agent_provider.mcorpc.agent_shim"]:
+      owner   => "root",
+      group   => "root",
+      mode    => "0755",
+      content => epp("choria/choria_mcollective_agent_compat.rb.epp")
+    }
+  }
+
+  file{$choria::server_config_file:
+    owner   => "root",
+    group   => "root",
+    mode    => "0640",
+    content => mcollective::hash2config($config),
+    notify  => Class["choria::service"],
+    require => Class["choria::install"]
+  }
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,27 +4,35 @@
 # @param nightly_repo Install the nightly package repo as well as the release one
 # @param ensure Add or remove the software
 # @param version The version of Choria to install
-# @param broker_config The configuration file for the broker
+# @param broker_config_file The configuration file for the broker
+# @param server_config_file The configuration file for the server
 # @param logfile The file to log to
 # @param loglevel The logging level to use
+# @param rubypath Path to the Ruby installation used for the MCollective compatability shims
 # @param srvdomain The domain name to use when doing SRV lookups
 # @param package_name The package to install
 # @param broker_service_name The service name of the Choria Broker
 # @param server_service_name The service name of the Choria Server
+# @param identity The identity this server will use to determine SSL cert names etc
 # @param server To enable or disable the choria server
+# @param server_config Configuration for the Choria Server
 class choria (
-  Boolean $manage_package_repo = false,
-  Boolean $nightly_repo = false,
-  Enum["present", "absent"] $ensure = "present",
-  String $version = "present",
-  Enum[debug, info, warn, error, fatal] $log_level = "warn",
-  Optional[String] $srvdomain = $facts["networking"]["domain"],
-  Stdlib::Compat::Absolute_path $broker_config = "/etc/choria/broker.conf",
-  Stdlib::Compat::Absolute_path $log_file = "/var/log/choria.log",
-  String $package_name = "choria",
-  String $broker_service_name = "choria-broker",
-  String $server_service_name = "choria-server",
-  Boolean $server = false,
+  Boolean $manage_package_repo ,
+  Boolean $nightly_repo,
+  Enum["present", "absent"] $ensure,
+  String $version,
+  Enum[debug, info, warn, error, fatal] $log_level,
+  Optional[String] $srvdomain,
+  Stdlib::Compat::Absolute_path $broker_config_file,
+  Stdlib::Compat::Absolute_path $server_config_file,
+  Stdlib::Compat::Absolute_path $log_file,
+  Stdlib::Compat::Absolute_path $rubypath,
+  String $package_name,
+  String $broker_service_name,
+  String $server_service_name,
+  String $identity,
+  Boolean $server,
+  Hash $server_config
 ) {
   if $manage_package_repo {
     class{"choria::repo":
@@ -35,7 +43,7 @@ class choria (
   }
 
   class{"choria::install": }
-
+  -> class{"choria::config": }
   -> class{"choria::service": }
 
   contain choria::install

--- a/spec/classes/broker/config_spec.rb
+++ b/spec/classes/broker/config_spec.rb
@@ -5,6 +5,7 @@ describe("choria::broker::config") do
     Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) {|_| }
   end
 
+  let(:node) { "choria1.rspec.example.net" }
   let(:facts) do
     {
       "aio_agent_version" => "1.7.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe("choria::config") do
+  before(:each) do
+    Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) {|_| }
+  end
+
+  let(:node) { "choria1.rspec.example.net" }
+  let(:facts) do
+    {
+      "aio_agent_version" => "1.7.0",
+      "operatingsystem" => "CentOS",
+      "osfamily" => "RedHat",
+      "operatingsystemmajrelease" => "7",
+      "networking" => {
+        "domain" => "rspec.example.net",
+        "fqdn" => "choria1.rspec.example.net"
+      },
+      "os" => {
+        "family" => "RedHat"
+      }
+    }
+  end
+
+  let(:pre_condition) { 'class {"choria": }' }
+
+  context("default server config") do
+    it "should work out of the box" do
+      is_expected.to contain_file("/etc/choria/server.conf")
+        .with_content(/logfile = .var.log.choria.log/)
+        .with_content(/loglevel = warn/)
+        .with_content(/identity = choria1.rspec.example.net/)
+        .with_content(/plugin.choria.srv_domain = rspec.example.net/)
+        .with_content(/collectives = mcollective/)
+        .with_content(/classesfile = \/opt\/puppetlabs\/puppet\/cache\/state\/classes.txt/)
+    end
+
+    it "should include the agent shim" do
+      is_expected.to contain_file("/usr/bin/choria_mcollective_agent_compat.rb")
+        .with_mode("0755")
+    end
+  end
+end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe("choria::install") do
+describe("choria::service") do
   before(:each) do
     Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) {|_| }
   end

--- a/templates/choria_mcollective_agent_compat.rb.epp
+++ b/templates/choria_mcollective_agent_compat.rb.epp
@@ -1,0 +1,90 @@
+#!<%= $choria::rubypath %>
+
+require "mcollective"
+
+@options = {}
+
+OptionParser.new do |opts|
+  opts.on("--config FILE", "Configuration to use for the MCollective subsystem") do |v|
+    @options["config"] = v
+  end
+end.parse!
+
+abort("Please specify a config file using --config") unless @options["config"]
+
+module MCollective
+  class AgentShim
+    def initialize(config, msg)
+      @config = config
+      @msg = msg
+    end
+
+    def loadconfig
+      config = MCollective::Config.instance
+      config.loadconfig(@config)
+    end
+
+    def request
+      @request ||= begin
+                     request = JSON.parse(@msg)
+                     symbolized_request = {}
+
+                     request.each do |k, v|
+                       symbolized_request[k.intern] = v
+                     end
+
+                     symbolized_request
+                   end
+    end
+
+    def agent
+      @agent ||= begin
+                   agent = MCollective::PluginManager.find_and_load(:agent) do |plugin|
+                     plugin == request[:agent]
+                   end.first
+
+                   if agent
+                     klass = Kernel.const_get(agent)
+                     if klass.ancestors.include?(MCollective::RPC::Agent) && klass.activate?
+                       klass.new
+                     end
+                   end
+                 end
+    end
+
+    def dispatch
+      abort("Unknown agent %s" % request[:agent]) unless agent
+
+      Log.debug("Dispatching request %s from %s@%s to %s#%s" % [request[:requestid], request[:callerid], request[:senderid], request[:body]["agent"], request[:body]["action"]])
+
+      reply = Timeout.timeout(agent.timeout) do
+        # technically the nil here should be a connector, no agent should be fiddling with that
+        # stuff really its ancient legacy for non RPC agents. RPC agents cannot access the connector
+        # some audit plugins might and so would agent hooks - this is all insane and stuff I just
+        # do not want to support, happy for them to fail
+        agent.handlemsg(request, nil)
+      end
+
+      reply.to_json
+
+    rescue Timeout::Error
+      Log.warn("Timeout while handling message %s from %s for agent %s" % [request[:requestid], request[:callerid], request[:agent]])
+      raise
+    rescue Exception # rubocop:disable Lint/RescueException
+      Log.error("Execution of %s failed: %s" % [request[:agent], $!.message])
+      Log.error($!.backtrace.join("\n\t\t"))
+      raise
+    end
+  end
+end
+
+begin
+  shim = MCollective::AgentShim.new(@options["config"], STDIN.read)
+  shim.loadconfig
+
+  puts shim.dispatch
+rescue Exception # rubocop:disable Lint/RescueException
+  STDERR.puts("%s failed: %s: %s" % [__FILE__, $!.class, $!.message])
+  STDERR.puts($!.backtrace.join("\n\t"))
+  puts({"statuscode" => 1, "statusmsg" => "Choria MCollective Compatability Layer failed to invoke the action: %s" % $!.message, "data" => {}}.to_json)
+end


### PR DESCRIPTION
This adds configuration of the choria server and the mco compat shim

To get there we:

 * extract class properties to hiera data
 * add server configuration
 * add the mcollective agent compatability shim and place it in place

In time the agent shim will move somewhere else - perhaps into the
go binary itself or a gem - for now this gets us somewhere workable