### PR TITLE
(#57) ensure auditing is on and in the right location

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,7 +1,8 @@
 ---
 choria::server_config:
   classesfile: "/opt/puppetlabs/puppet/cache/state/classes.txt"
-  plugin.rpcaudit.logfile: "/var/log/puppetlabs/mcollective-audit.log"
+  rpcaudit: 1
+  plugin.rpcaudit.logfile: "/var/log/choria-audit.log"
   plugin.yaml: "/etc/puppetlabs/mcollective/generated-facts.yaml"
   plugin.choria.agent_provider.mcorpc.agent_shim: "/usr/bin/choria_mcollective_agent_compat.rb"
   plugin.choria.agent_provider.mcorpc.config: "/etc/puppetlabs/mcollective/server.cfg"

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,7 +1,6 @@
 ---
 choria::server_config:
   classesfile: "/var/puppet/state/classes.txt"
-  plugin.rpcaudit.logfile: "/var/log/mcollective-audit.log"
   plugin.yaml: "/usr/local/etc/mcollective/generated-facts.yaml"
   plugin.choria.agent_provider.mcorpc.agent_shim: "/usr/local/bin/choria_mcollective_agent_compat.rb"
   plugin.choria.agent_provider.mcorpc.config: "/usr/local/etc/mcollective/server.cfg"


### PR DESCRIPTION
This ensures that by default auditing is on for the choria daemon and
that it logs to the new location /var/log/${name}-audit.log