### PR TITLE
(#59) use the shim specific mcollective config

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -5,7 +5,7 @@ choria::server_config:
   plugin.rpcaudit.logfile: "/var/log/choria-audit.log"
   plugin.yaml: "/etc/puppetlabs/mcollective/generated-facts.yaml"
   plugin.choria.agent_provider.mcorpc.agent_shim: "/usr/bin/choria_mcollective_agent_compat.rb"
-  plugin.choria.agent_provider.mcorpc.config: "/etc/puppetlabs/mcollective/server.cfg"
+  plugin.choria.agent_provider.mcorpc.config: "/etc/puppetlabs/mcollective/choria-shim.cfg"
   plugin.choria.agent_provider.mcorpc.libdir: "/opt/puppetlabs/mcollective/plugins"
 
 choria::rubypath: "/opt/puppetlabs/puppet/bin/ruby"

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -3,7 +3,7 @@ choria::server_config:
   classesfile: "/var/puppet/state/classes.txt"
   plugin.yaml: "/usr/local/etc/mcollective/generated-facts.yaml"
   plugin.choria.agent_provider.mcorpc.agent_shim: "/usr/local/bin/choria_mcollective_agent_compat.rb"
-  plugin.choria.agent_provider.mcorpc.config: "/usr/local/etc/mcollective/server.cfg"
+  plugin.choria.agent_provider.mcorpc.config: "/usr/local/etc/mcollective/choria-shim.cfg"
   plugin.choria.agent_provider.mcorpc.libdir: "/usr/local/share"
 
 choria::rubypath: "/usr/local/bin/ruby"

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 5.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 4.5.1 < 6.0.0" },
     { "name": "choria/mcollective_choria", "version_requirement": ">= 0.8.0 < 2.0.0" },
-    { "name": "choria/mcollective", "version_requirement": ">= 0.5.0 < 2.0.0" }
+    { "name": "choria/mcollective", "version_requirement": ">= 0.6.0 < 2.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Eventually we must create the shim config in this module, but as a
intermediate phase we are creating it in the mcollective module to
avoid issues with passing policies around and so forth.

This uses the configuration made there that has auditing and so off