### PR TITLE
(#61) Support Puppet Tasks

### DIFF
--- a/lib/puppet/functions/choria/tasks/metadata.rb
+++ b/lib/puppet/functions/choria/tasks/metadata.rb
@@ -1,0 +1,29 @@
+# Downloads metadata for a Puppet Task
+#
+# This helper downloads the specification of a task from the Puppet Server, for this to work
+# you should have followed the configuration guide at [choria.io](https://choria.io) to ensure
+# the required Puppet Server configuration were complete
+Puppet::Functions.create_function(:"choria::tasks::metadata") do
+  dispatch :fetch do
+    param "String", :task
+  end
+
+  def init
+    require_relative "../../../_load_choria"
+  end
+
+  def choria
+    @_choria ||= begin
+       init
+       MCollective::Util::Choria.new
+    end
+  end
+
+  def tasks_support
+    @__tasks ||= choria.tasks_support
+  end
+
+  def fetch(task)
+    tasks_support.task_metadata(task, "production")
+  end
+end

--- a/lib/puppet/functions/choria/tasks/validate_input.rb
+++ b/lib/puppet/functions/choria/tasks/validate_input.rb
@@ -1,0 +1,32 @@
+# Validates that the input given would be acceptable to a task described by `metadata`
+#
+# @returns [Boolean]
+Puppet::Functions.create_function(:"choria::tasks::validate_input") do
+  dispatch :validate do
+    param "Hash", :input
+    param "Hash", :metadata
+  end
+
+  def init
+    require_relative "../../../_load_choria"
+  end
+
+  def choria
+    @_choria ||= begin
+       init
+       MCollective::Util::Choria.new
+    end
+  end
+
+  def tasks_support
+    @__tasks ||= choria.tasks_support
+  end
+
+  def validate(input, metadata)
+    ok, reason = tasks_support.validate_task_inputs(input, metadata)
+
+    return true if ok
+
+    raise(reason)
+  end
+end

--- a/plans/tasks/download_files.pp
+++ b/plans/tasks/download_files.pp
@@ -1,0 +1,26 @@
+# Download the files of associated with a task onto the nodes
+#
+# @param nodes The nodes to download onto
+# @param files The files section of the task metadata
+# @param task The name of the task
+# @return [Choria::TaskResults]
+plan choria::tasks::download_files(
+  String $task,
+  Array[Hash] $files,
+  Choria::Nodes $nodes
+) {
+  info("Downloading files for task ${task} onto ${nodes.size} nodes")
+
+  choria::task(
+    "nodes"            => $nodes,
+    "action"           => "bolt_tasks.download",
+    "batch_size"       => 50,
+    "batch_sleep_time" => 1,
+    "silent"           => true,
+    "properties"       => {
+      "environment"    => "production",
+      "task"           => $task,
+      "files"          => $files.to_json
+    }
+  )
+}

--- a/plans/tasks/run.pp
+++ b/plans/tasks/run.pp
@@ -1,0 +1,57 @@
+# Runs a specific Puppet Task
+#
+# When running in the background and in batches this does not imply
+# that the task is completed between batches it means the task will
+# be requested in these batches regardless of the state of the other nodes
+#
+# When run in the foregroun it will wait up to 60 seconds for nodes to
+# complete a task, if by then they did not complete the task it will move
+# onto the next batch
+#
+# @param nodes The nodes to run the task on
+# @param task The name of the task to run
+# @param inputs The inputs to pass to the task
+# @param background When true does not wait for the task to complete
+# @param silent Surpress logging of individual node results
+# @param batch_size When not 0, run the task on nodes in batches
+# @params batch_sleep_time How long to sleep between batches
+plan choria::tasks::run(
+  Choria::Nodes $nodes,
+  String $task,
+  Hash $inputs,
+  Boolean $background = false,
+  Boolean $silent = false,
+  Integer $batch_size = 0,
+  Integer $batch_sleep_time = 2
+) {
+  info("Running task ${task} on ${nodes.size} nodes")
+
+  $metadata = choria::tasks::metadata($task)
+
+  choria::tasks::validate_input($inputs, $metadata)
+
+  choria::run_playbook("acme::tasks::download_files",
+    "nodes" => $nodes,
+    "task"  => $task,
+    "files" => $metadata["files"]
+  )
+
+  if $background {
+    $action = "bolt_tasks.run_no_wait"
+  } else {
+    $action = "bolt_tasks.run_and_wait"
+  }
+
+  choria::task(
+    "nodes"            => $nodes,
+    "action"           => $action,
+    "batch_size"       => $batch_size,
+    "batch_sleep_time" => $batch_sleep_time,
+    "silent"           => $silent,
+    "properties"       => {
+      "task"           => $task,
+      "files"          => $metadata["files"].to_json,
+      "input"          => $inputs.to_json
+    }
+  )
+}

--- a/plans/tasks/status.pp
+++ b/plans/tasks/status.pp
@@ -1,0 +1,26 @@
+# Retrieves the status of a task from a set of nodes
+#
+# Should any of the nodes not have run the task the task
+# status retrival will fail unless fail_ok is true
+#
+# @param task_id The task ID to retrieve
+# @param nodes The nodes to fetch the id from
+# @param fail_ok When true failure to fetch the status from some nodes will not result in a playbook failure
+# @return [Choria::TaskResults]
+plan choria::tasks::status (
+  String $task_id,
+  Choria::Nodes $nodes,
+  Boolean $fail_ok = false
+) {
+  info("Retrieving task status of task ${task_id} from ${nodes.size} nodes")
+
+  choria::task(
+    "nodes"      => $nodes,
+    "action"     => "bolt_tasks.task_status",
+    "silent"     => true,
+    "fail_ok"    => $fail_ok,
+    "properties" => {
+      "task_id"  => $task_id
+    }
+  )
+}

--- a/plans/tasks/wait.pp
+++ b/plans/tasks/wait.pp
@@ -1,0 +1,46 @@
+# Waits for a task to complete on all nodes
+#
+# @param task_id The task ID to check
+# @param nodes The nodes to check the task on
+# @param tries How many times to perform the check before failing
+# @param sleep How long to wait between checks
+# @return [Boolean] indicates task completion
+plan acme::tasks::wait (
+  String $task_id,
+  Choria::Nodes $nodes,
+  Integer $tries = 90,
+  Integer $sleep = 20
+) {
+  info("Waiting for task ${task_id} to complete on ${nodes.size} nodes")
+
+  range(1, $tries).each |$try| {
+    $results = choria::task(
+      "nodes"      => $nodes,
+      "action"     => "bolt_tasks.task_status",
+      "silent"     => true,
+      "pre_sleep"  => $sleep,
+      "properties" => {
+        "task_id"  => $task_id
+      }
+    )
+
+    $completed = $results.map |$result| {
+      $result["data"]["completed"]
+    }
+
+    unless false in $completed {
+      info("Task ${task_id} completed after ${try} checks")
+      return true
+    }
+
+    $running = $completed.filter |$c| { $c == false }
+
+    unless $try == $tries {
+      warning("Waiting for ${running.size} node(s) to complete task ${task_id} check ${try} / ${tries}")
+    }
+  }
+
+  err("Task ${task_id} did not complete after ${tries} checks")
+
+  return false
+}


### PR DESCRIPTION
This adds playbooks and tasks needed to support running Puppet Tasks
within the Playbook framework

Relates to https://github.com/choria-io/mcollective-choria/issues/446