### PR TITLE
(#66) Allow nodes to fail during task::wait playbook

### DIFF
--- a/plans/tasks/wait.pp
+++ b/plans/tasks/wait.pp
@@ -1,15 +1,26 @@
 # Waits for a task to complete on all nodes
 #
+# A note about the use of `fail_ok`, this will instruct the system
+# to not consider nodes that failed as part of the determination of
+# completion and to assume the nodes that did respond well are representitive.
+#
+# This may have a undesired outcome where 1 completed node that is not
+# failing can completely mask 999 failing nodes none of whome have completed.
+# You need to use this flag with caution and be aware of the possible impact.
+# It is therefor off by default.
+#
 # @param task_id The task ID to check
 # @param nodes The nodes to check the task on
 # @param tries How many times to perform the check before failing
 # @param sleep How long to wait between checks
+# @param fail_ok Allow some nodes to fail the actual check call
 # @return [Boolean] indicates task completion
 plan choria::tasks::wait (
   String $task_id,
   Choria::Nodes $nodes,
   Integer $tries = 90,
-  Integer $sleep = 20
+  Integer $sleep = 20,
+  Boolean $fail_ok = false
 ) {
   info("Waiting for task ${task_id} to complete on ${nodes.size} nodes")
 
@@ -19,12 +30,13 @@ plan choria::tasks::wait (
       "action"     => "bolt_tasks.task_status",
       "silent"     => true,
       "pre_sleep"  => $sleep,
+      "fail_ok"    => $fail_ok,
       "properties" => {
         "task_id"  => $task_id
       }
     )
 
-    $completed = $results.map |$result| {
+    $completed = $results.ok_set.map |$result| {
       $result["data"]["completed"]
     }
 


### PR DESCRIPTION
It could be that nodes are restarting, or something about the task
interrupting service or maybe the task is trying to do recovery
after some bad deploy - regardless there are cases where we just can
not assume all nodes will respond on this status call.

Now when someone passes fail_ok it signals that they wish to ignore
failures while waiting but could lead to surprising outcomes where
1 out of 1000 nodes did not fail and 999 failed - and then the wait
will finish, use with caution.