### PR TITLE
(#73) use different fact to detect Ubuntu

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,7 +35,7 @@ class choria::repo (
         metadata_expire => 300,
       }
     }
-  } elsif fact("os.distro.id") == "Ubuntu" {
+  } elsif $facts["os"]["name"] == "Ubuntu" {
     apt::source{"choria-release":
       ensure        => $ensure,
       notify_update => true,


### PR DESCRIPTION
the os.distro.id path isn't available on facter2.5. That version is
still pretty common, especially for people using rpsec-puppet and
rspec-puppet-facts.

Closes #73 