### PR TITLE
(#84) Collect results of each block and return them back

### DIFF
--- a/lib/puppet/functions/choria/in_groups_of.rb
+++ b/lib/puppet/functions/choria/in_groups_of.rb
@@ -27,12 +27,16 @@ Puppet::Functions.create_function(:"choria::in_groups_of") do
 
     count = (arr.size / Float(chunk_size)).ceil
 
-    result = []
+    groups = []
+    
+    results = []
 
-    count.times {|s| result <<  arr[s * chunk_size, chunk_size]}
+    count.times {|s| groups <<  arr[s * chunk_size, chunk_size]}
 
-    result.each_with_index do |a|
-      yield(a)
+    groups.each_with_index do |a|
+      results << yield(a)
     end
+
+    results
   end
 end


### PR DESCRIPTION
The current iteration of the function will just return back a list of the "items" passed in, which in my particular case is the hostname.  I'd like the return to include the return of each block.

Implements #84 