### PR TITLE
Fix typo s/compatability/compatibility/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ it can be used for such and such.
 To deliver this feature we had to extend, this that and the other
 with new behaviours
 
-Backwards compatability is kept
+Backwards compatibility is kept
 ```
 
 Please see [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/) for excellent coverage of the topic of commit messages.  We don't require things to be as detailed or strict as that but it's a great resource to keep in mind.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@
 # @param server_config_file The configuration file for the server
 # @param logfile The file to log to
 # @param log_level The logging level to use
-# @param rubypath Path to the Ruby installation used for the MCollective compatability shims
+# @param rubypath Path to the Ruby installation used for the MCollective compatibility shims
 # @param srvdomain The domain name to use when doing SRV lookups
 # @param package_name The package to install
 # @param broker_service_name The service name of the Choria Broker

--- a/templates/choria_mcollective_agent_compat.rb.epp
+++ b/templates/choria_mcollective_agent_compat.rb.epp
@@ -154,12 +154,12 @@ module MCollective
 
     rescue Timeout::Error
       Log.warn("Timeout while handling message %s from %s for agent %s" % [request[:requestid], request[:callerid], request[:agent]])
-      {"statuscode" => 1, "statusmsg" => "Choria MCollective Compatability Layer failed to invoke the action: %s" % $!.message, "data" => {}}
+      {"statuscode" => 1, "statusmsg" => "Choria MCollective Compatibility Layer failed to invoke the action: %s" % $!.message, "data" => {}}
 
     rescue Exception # rubocop:disable Lint/RescueException
       Log.error("Execution of %s failed: %s" % [request[:agent], $!.message])
       Log.error($!.backtrace.join("\n\t\t"))
-      {"statuscode" => 1, "statusmsg" => "Choria MCollective Compatability Layer failed to invoke the action: %s" % $!.message, "data" => {}}
+      {"statuscode" => 1, "statusmsg" => "Choria MCollective Compatibility Layer failed to invoke the action: %s" % $!.message, "data" => {}}
     end
   end
 end


### PR DESCRIPTION
Found this while looking into bringing tasks support to life for FreeBSD :smiley: