### PR TITLE
(#113) Ensure the choria repository is managed before the choria package

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -53,7 +53,8 @@ class choria::repo (
       key           => {
         id     => "5921BC1D903D6E0353C985BB9F89253B1E83EA92",
         source => "https://packagecloud.io/choria/release/gpgkey"
-      }
+      },
+      before        => Package[$choria::package_name],
     }
   } elsif $facts["os"]["name"] == "Debian" {
     apt::source{"choria-release":
@@ -66,7 +67,8 @@ class choria::repo (
       key           => {
         id     => "5921BC1D903D6E0353C985BB9F89253B1E83EA92",
         source => "https://packagecloud.io/choria/release/gpgkey"
-      }
+      },
+      before        => Package[$choria::package_name],
     }
   } else {
     fail(sprintf("Choria Repositories are not supported on %s", $facts["os"]["family"]))


### PR DESCRIPTION
Without this dependency, Puppet sometimes try to install the choria package before managing the choria repository, resulting in a failed run.

I suspect the same problem exist with yum repositories, but am not a user of it so would prefer to have feedback from somebody who knows before adding more dependency if they are required.