### PR TITLE
(#115) Support additional broker configuration

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -42,6 +42,8 @@ choria::broker::collective_middleware_hosts: []
 choria::broker::adapters: {}
 choria::broker::identity: "%{trusted.certname}"
 
+choria::broker_config: {}
+
 lookup_options:
   choria::collectives:
     merge: "unique"

--- a/manifests/broker/config.pp
+++ b/manifests/broker/config.pp
@@ -4,6 +4,8 @@
 class choria::broker::config {
   assert_private()
 
+  $config = choria::hash2config($choria::broker_config)
+
   file{$choria::broker_config_file:
     owner   => "root",
     group   => $choria::root_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ class choria (
   String $identity,
   Boolean $server,
   Hash $server_config,
+  Hash $broker_config,
   String $root_group,
 ) {
   if $manage_package_repo {

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -65,3 +65,6 @@ plugin.choria.adapter.<%= $adapter %>.<%= $section %>.<%= $key %> = <%= $value %
 <%      } -%>
 <%   } -%>
 <% } -%>
+<% unless $choria::broker::config::config.empty { -%>
+<%= $choria::broker::config::config %>
+<% } -%>


### PR DESCRIPTION
Fixes #115

Support adding additional keys by way of data in hiera - things like
specifying file security, etc.