### PR TITLE
(#121) Allow top-level choria::server_config options to be arrays

### DIFF
--- a/functions/hash2config.pp
+++ b/functions/hash2config.pp
@@ -2,7 +2,19 @@
 # key = value
 function choria::hash2config(Hash $confighash) >> String {
   $result = $confighash.keys.sort.map |$key| {
-    sprintf("%s = %s", $key, $confighash[$key])
+    $val = $confighash[$key]
+
+    if $val =~ Array {
+      $val.each |$item| {
+        unless $item =~ Integer or $item =~ Float or $item =~ String {
+          fail("Array values are only supported for Integer, Float or String data types")
+        }
+      }
+
+      sprintf("%s = %s", $key, $val.join(", "))
+    } else {
+      sprintf("%s = %s", $key, $val)
+    }
   }
   ($result << []).join("\n")
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -51,4 +51,17 @@ describe("choria::config") do
       end
     end
   end
+
+  context("custom server config") do
+    let(:pre_condition) {
+      'class {"choria":
+         server_config => {"plugin.choria.security.certname_whitelist" => ["user1", "user2"]},
+       }'
+    }
+
+    it "should support arrays in choria::server_config" do
+      is_expected.to contain_file("/etc/choria/server.conf")
+        .with_content(/plugin.choria.security.certname_whitelist = user1, user2/)
+    end
+  end
 end


### PR DESCRIPTION
I think this will work, but I need a little help with writing a test for it