### PR TITLE
(#130) Allow splitting services log configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,8 +18,8 @@ class choria::config {
   }
 
   $config = $defaults + $choria::server_config + $status + {
-    "logfile"                    => $choria::logfile,
-    "loglevel"                   => $choria::log_level,
+    "logfile"                    => $choria::server_logfile,
+    "loglevel"                   => $choria::server_log_level,
     "identity"                   => $choria::identity,
     "plugin.choria.srv_domain"   => $choria::srvdomain,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,10 +8,14 @@
 # @param mcollective_config_dir Directory where mcollective configuration is stored
 # @param broker_config_file The configuration file for the broker
 # @param server_config_file The configuration file for the server
-# @param logfile The file to log to
+# @param logfile The default file to log to
+# @param broker_logfile The file to log the broker to
+# @param server_logfile The file to log the server to
 # @param statusfile The file to write server status to
 # @param status_write_interval How often the status file should be written in seconds
-# @param log_level The logging level to use
+# @param log_level The default logging level to use
+# @param broker_log_level The logging level to use for the broker
+# @param server_log_level The logging level to use for the server
 # @param rubypath Path to the Ruby installation used for the MCollective compatibility shims
 # @param srvdomain The domain name to use when doing SRV lookups
 # @param package_name The package to install
@@ -42,6 +46,10 @@ class choria (
   Boolean $server,
   Hash $server_config,
   String $root_group,
+  Enum[debug, info, warn, error, fatal] $broker_log_level = $log_level,
+  Enum[debug, info, warn, error, fatal] $server_log_level = $log_level,
+  Stdlib::Compat::Absolute_path $broker_logfile = $logfile,
+  Stdlib::Compat::Absolute_path $server_logfile = $logfile,
 ) {
   if $manage_package_repo {
     class{"choria::repo":

--- a/spec/classes/broker/config_spec.rb
+++ b/spec/classes/broker/config_spec.rb
@@ -44,6 +44,15 @@ describe("choria::broker::config") do
           .with_content(/identity = custom.rspec.example.net/)
       end
     end
+
+    context("custom logging") do
+      let(:pre_condition) { 'class {"choria": broker_logfile => "/var/log/choria-broker.log", broker_log_level => "debug"} class {"choria::broker": }' }
+
+      it "should use the supplied logging" do
+        is_expected.to contain_file("/etc/choria/broker.conf").with_content(/logfile = \/var\/log\/choria-broker\.log/)
+          .with_content(/loglevel = debug/)
+      end
+    end
   end
 
   context("without the network broker") do

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -64,4 +64,13 @@ describe("choria::config") do
         .with_content(/plugin.choria.security.certname_whitelist = user1, user2/)
     end
   end
+
+  context("custom logging") do
+    let(:pre_condition) { 'class {"choria": server_logfile => "/var/log/choria-server.log", server_log_level => "debug"}' }
+
+    it "should use the supplied logging" do
+      is_expected.to contain_file("/etc/choria/server.conf").with_content(/logfile = \/var\/log\/choria-server\.log/)
+        .with_content(/loglevel = debug/)
+    end
+  end
 end

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -1,5 +1,5 @@
-logfile = <%= $choria::logfile %>
-loglevel = <%= $choria::log_level %>
+logfile = <%= $choria::broker_logfile %>
+loglevel = <%= $choria::broker_log_level %>
 identity = <%= $choria::broker::identity %>
 
 <% if $choria::srvdomain { -%>


### PR DESCRIPTION
Introduce new parameters to configure different logfile and log_levels
for the server and broker:

* choria::broker_logfile
* choria::broker_log_level
* choria::server_logfile
* choria::server_log_level

When unset, these variable default to choria::logfile and choria::log_level which default value is unchanged, so no impact on the end-user.