### PR TITLE
(misc) Bump puppetlabs-stdlib version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/choria-io/puppet-choria",
   "issues_url": "https://github.com/choria-io/puppet-choria/issues",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 6.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 7.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 4.5.1 < 8.0.0" },
     { "name": "choria/mcollective_choria", "version_requirement": ">= 0.16.0 < 2.0.0" },
     { "name": "choria/mcollective", "version_requirement": ">= 0.10.0 < 2.0.0" }


### PR DESCRIPTION
Tested with stdlib v6.0.0. Looks good so far.