### PR TITLE
(#113) Improve resources ordering

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -63,6 +63,7 @@ class choria::repo (
       },
       before        => Package[$choria::package_name],
     }
+    Class['apt::update'] -> Package[$choria::package_name]
   } elsif $facts["os"]["name"] == "Debian" {
     apt::source{"choria-release":
       ensure        => $ensure,
@@ -77,6 +78,7 @@ class choria::repo (
       },
       before        => Package[$choria::package_name],
     }
+    Class['apt::update'] -> Package[$choria::package_name]
   } else {
     fail(sprintf("Choria Repositories are not supported on %s", $facts["os"]["family"]))
   }


### PR DESCRIPTION
When using APT to manage packages, it is necessary to run `apt-get update` to update the list of available packages before installing a new one.  The puppetlabs-apt module has the `apt::update` class which is in charge of this and is optionally notified by the `apt::source` resources (enabled by default).

Adjust the dependencies so that we have:

    Apt::Source['choria'] ~> Class['apt::update'] (optional, site-dependant)
    Apt::Source['choria'] -> Package['choria']
    Class['apt::update']  -> Package['choria']

instead of the previous:

    Apt::Source['choria'] ~> Class['apt::update'] (optional, site-dependant)
    Apt::Source['choria'] -> Package['choria']

That way, if `apt::update` has something to do, we do not end-up with a failed run because installation of choria is performed before updating the available package list.

This conforms to the recommendation of the module documentation:
https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas

> your package resource should depend on Class['apt::update'], as well as depending on the Apt::Source