### PR TITLE
(#145) First step of Windows support

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -9,6 +9,8 @@ choria::server_config:
   plugin.choria.agent_provider.mcorpc.libdir: "/opt/puppetlabs/mcollective/plugins"
 
 choria::rubypath: "/opt/puppetlabs/puppet/bin/ruby"
+choria::manage_package: true
+choria::manage_service: true
 choria::manage_package_repo: false
 choria::nightly_repo: false
 choria::repo_baseurl: "https://packagecloud.io/choria"
@@ -27,7 +29,8 @@ choria::broker_service_name: "choria-broker"
 choria::server_service_name: "choria-server"
 choria::identity: "%{trusted.certname}"
 choria::server: false
-choria::root_group: "root"
+choria::config_user: "root"
+choria::config_group: "root"
 
 choria::broker::network_broker: true
 choria::broker::federation_broker: false

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -9,5 +9,5 @@ choria::server_config:
 choria::rubypath: "/usr/local/bin/ruby"
 choria::broker_config_file: "/usr/local/etc/choria/broker.conf"
 choria::server_config_file: "/usr/local/etc/choria/server.conf"
-choria::root_group: "wheel"
+choria::config_group: "wheel"
 choria::mcollective_config_dir: "/usr/local/etc/mcollective"

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,2 +1,19 @@
 ---
-choria::mcollective_config_dir: "C:/ProgramData/PuppetLabs/mcollective/etc"
+choria::server_config:
+  plugin.rpcaudit.logfile: "C:/ProgramData/choria/var/log/choria-audit.log"
+  classesfile: "C:/ProgramData/PuppetLabs/puppet/cache/state/classes.txt"
+  plugin.rpcaudit.logfile: "C:/ProgramData/choria/var/log/choria-audit.log"
+  plugin.yaml: "C:/ProgramData/choria/etc/generated-facts.yaml"
+  plugin.choria.agent_provider.mcorpc.agent_shim: "C:/Program Files/choria/bin/choria_mcollective_agent_compat.rb"
+  plugin.choria.agent_provider.mcorpc.config: "C:/ProgramData/choria/etc/choria-shim.cfg"
+  plugin.choria.agent_provider.mcorpc.libdir: "C:/ProgramData/choria/lib/plugins"
+choria::rubypath: "C:/Program Files/Puppet Labs/Puppet/puppet/bin/ruby.exe"
+choria::broker_config_file: "C:/ProgramData/choria/etc/broker.conf"
+choria::server_config_file: "C:/ProgramData/choria/etc/server.conf"
+choria::logfile: "C:/ProgramData/choria/var/log/choria.log"
+choria::statusfile: "C:/ProgramData/choria/var/log/choria-status.json"
+choria::manage_package: false
+choria::manage_service: false
+choria::mcollective_config_dir: "C:/ProgramData/choria/etc"
+choria::config_user: ~
+choria::config_group: ~

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,16 +42,16 @@ class choria::config {
 
   if "plugin.choria.agent_provider.mcorpc.agent_shim" in $choria::server_config  and "plugin.choria.agent_provider.mcorpc.config" in $choria::server_config {
     file{$choria::server_config["plugin.choria.agent_provider.mcorpc.agent_shim"]:
-      owner   => "root",
-      group   => $choria::root_group,
+      owner   => $choria::config_user,
+      group   => $choria::config_group,
       mode    => "0755",
       content => epp("choria/choria_mcollective_agent_compat.rb.epp")
     }
   }
 
   file{$choria::server_config_file:
-    owner   => "root",
-    group   => $choria::root_group,
+    owner   => $choria::config_user,
+    group   => $choria::config_group,
     mode    => "0640",
     content => choria::hash2config($config),
     notify  => Class["choria::service"],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,7 @@
 # Installs, configures and manages the Choria Orchestrator
 #
+# @param manage_package Manage the choria package
+# @param manage_service Manage the choria-server package
 # @param manage_package_repo Installs the package repositories
 # @param nightly_repo Install the nightly package repo as well as the release one
 # @param ensure Add or remove the software
@@ -25,6 +27,8 @@
 # @param server To enable or disable the choria server
 # @param server_config Configuration for the Choria Server
 class choria (
+  Boolean $manage_package,
+  Boolean $manage_service,
   Boolean $manage_package_repo ,
   Boolean $nightly_repo,
   Enum["present", "absent"] $ensure,
@@ -45,7 +49,8 @@ class choria (
   String $identity,
   Boolean $server,
   Hash $server_config,
-  String $root_group,
+  Optional[String] $config_user,
+  Optional[String] $config_group,
   Enum[debug, info, warn, error, fatal] $broker_log_level = $log_level,
   Enum[debug, info, warn, error, fatal] $server_log_level = $log_level,
   Stdlib::Compat::Absolute_path $broker_logfile = $logfile,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,12 +4,14 @@
 class choria::install {
   assert_private()
 
-  $version = $choria::ensure ? {
-    "present" => $choria::version,
-    "absent" => "absent"
-  }
+  if $choria::manage_package {
+    $version = $choria::ensure ? {
+      "present" => $choria::version,
+      "absent" => "absent"
+    }
 
-  package{$choria::package_name:
-    ensure => $version
+    package{$choria::package_name:
+      ensure => $version
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,29 +4,31 @@
 class choria::service {
   assert_private()
 
-  if $choria::server {
-    service{$choria::server_service_name:
-      ensure => "running",
-      enable => true
-    }
+  if $choria::manage_service {
+    if $choria::server {
+      service{$choria::server_service_name:
+        ensure => "running",
+        enable => true
+      }
 
-    # Since the installation of mcollective plugins are handled in another module at
-    # the moment we have to do this ugly hackery here to ensure we restart choria
-    # service when new plugins are installed
-    #
-    # Eventually this module will own installation of plugins and things will improve
-    # for now its a bit meh
-    Service<| title == "mcollective" |> ~> Service[$choria::server_service_name]
+      # Since the installation of mcollective plugins are handled in another module at
+      # the moment we have to do this ugly hackery here to ensure we restart choria
+      # service when new plugins are installed
+      #
+      # Eventually this module will own installation of plugins and things will improve
+      # for now its a bit meh
+      Service<| title == "mcollective" |> ~> Service[$choria::server_service_name]
 
-    # Without this when a mcollective plugin is removed if purge is on the service
-    # would not be restarted, unfortunate side effect that a client uninstall will
-    # also yield a restart
-    File<| tag == "mcollective::plugin_dirs" |> ~> Service[$choria::server_service_name]
+      # Without this when a mcollective plugin is removed if purge is on the service
+      # would not be restarted, unfortunate side effect that a client uninstall will
+      # also yield a restart
+      File<| tag == "mcollective::plugin_dirs" |> ~> Service[$choria::server_service_name]
 
-  } else {
-    service{$choria::server_service_name:
-      ensure => "stopped",
-      enable => false
+    } else {
+      service{$choria::server_service_name:
+        ensure => "stopped",
+        enable => false
+      }
     }
   }
 }


### PR DESCRIPTION
These commits make the module produce a valid catalog for Windows hosts.  This is not enough for running Choria on Windows, since the following pieces are missing:

* An `*.msi` file to install choria ([POC here](https://github.com/smortex/go-choria/tree/windows))
* Ability to run choria as a windows service ([hint](https://golang.org/x/sys/windows/svc))
* ~~Parent directories for the managed files (to be managed by the installer, see above)~~ (they are now managed by the mcollective plugin)