### PR TITLE
(#142) Add `choria::sleep` function

### DIFF
--- a/lib/puppet/functions/choria/sleep.rb
+++ b/lib/puppet/functions/choria/sleep.rb
@@ -1,0 +1,10 @@
+# Sleep for N seconds
+Puppet::Functions.create_function(:"choria::sleep") do
+  dispatch :do_sleep do
+    param "Integer", :seconds
+  end
+
+  def do_sleep(seconds)
+    sleep(seconds)
+  end
+end


### PR DESCRIPTION
This function allows to stop playbook execution for specified amount of seconds.

This closes #142 