### PR TITLE
(#145) Manage a wrapper for running ruby on Windows

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -4,7 +4,7 @@ choria::server_config:
   classesfile: "C:/ProgramData/PuppetLabs/puppet/cache/state/classes.txt"
   plugin.rpcaudit.logfile: "C:/ProgramData/choria/var/log/choria-audit.log"
   plugin.yaml: "C:/ProgramData/choria/etc/generated-facts.yaml"
-  plugin.choria.agent_provider.mcorpc.agent_shim: "C:/Program Files/choria/bin/choria_mcollective_agent_compat.rb"
+  plugin.choria.agent_provider.mcorpc.agent_shim: "C:/Program Files/choria/bin/choria_mcollective_agent_compat.bat"
   plugin.choria.agent_provider.mcorpc.config: "C:/ProgramData/choria/etc/choria-shim.cfg"
   plugin.choria.agent_provider.mcorpc.libdir: "C:/ProgramData/choria/lib/plugins"
 choria::rubypath: "C:/Program Files/Puppet Labs/Puppet/puppet/bin/ruby.exe"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,11 +41,27 @@ class choria::config {
   }
 
   if "plugin.choria.agent_provider.mcorpc.agent_shim" in $choria::server_config  and "plugin.choria.agent_provider.mcorpc.config" in $choria::server_config {
-    file{$choria::server_config["plugin.choria.agent_provider.mcorpc.agent_shim"]:
+    if $choria::server_config["plugin.choria.agent_provider.mcorpc.agent_shim"] =~ /\.bat$/ {
+      $agent_shim = $choria::server_config["plugin.choria.agent_provider.mcorpc.agent_shim"].regsubst(/\.bat$/, '.rb')
+      $agent_shim_wrapper = $choria::server_config["plugin.choria.agent_provider.mcorpc.agent_shim"]
+    } else {
+      $agent_shim = $choria::server_config["plugin.choria.agent_provider.mcorpc.agent_shim"]
+      $agent_shim_wrapper = undef
+    }
+
+    file{$agent_shim:
       owner   => $choria::config_user,
       group   => $choria::config_group,
       mode    => "0755",
       content => epp("choria/choria_mcollective_agent_compat.rb.epp")
+    }
+    if $agent_shim_wrapper {
+      file{$agent_shim_wrapper:
+        owner   => $choria::config_user,
+        group   => $choria::config_group,
+        mode    => "0755",
+        content => epp("choria/choria_mcollective_agent_compat.bat.epp")
+      }
     }
   }
 

--- a/templates/choria_mcollective_agent_compat.bat.epp
+++ b/templates/choria_mcollective_agent_compat.bat.epp
@@ -1,0 +1,3 @@
+@echo off
+setlocal
+"<%= $choria::rubypath %>" -S -- "<%= $choria::server_config["plugin.choria.agent_provider.mcorpc.agent_shim"].regsubst(/\.bat$/, '.rb') %>" --config "<%= $choria::server_config_file %>" %*


### PR DESCRIPTION
Inspired by https://github.com/choria-io/puppet-choria/issues/145#issuecomment-575381929

When the agent_shim filename ends with '.bat', install a wrapper batch file that run the actual '.rb' file; otherwise, just install the '.rb' file and run it directly as before.