### PR TITLE
(#115) Added ssldir parameter to broker config.

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -7,6 +7,7 @@ choria::server_config:
   plugin.choria.agent_provider.mcorpc.agent_shim: "C:/Program Files/choria/bin/choria_mcollective_agent_compat.bat"
   plugin.choria.agent_provider.mcorpc.config: "C:/ProgramData/choria/etc/choria-shim.cfg"
   plugin.choria.agent_provider.mcorpc.libdir: "C:/ProgramData/choria/lib/plugins"
+  plugin.choria.ssldir: "C:/ProgramData/PuppetLabs/puppet/etc/ssl"
 choria::rubypath: "C:/Program Files/Puppet Labs/Puppet/puppet/bin/ruby.exe"
 choria::broker_config_file: "C:/ProgramData/choria/etc/broker.conf"
 choria::server_config_file: "C:/ProgramData/choria/etc/server.conf"

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -65,6 +65,7 @@ class choria::broker (
   Array[String] $client_hosts,
   Choria::Adapters $adapters,
   String $identity,
+  Optional[Stdlib::Absolutepath] $ssldir = undef,
   Optional[Integer] $tls_timeout = undef,
 ) {
   require choria

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -46,6 +46,11 @@ plugin.choria.network.peers = <%= $choria::broker::network_peers.join(", ") %>
 plugin.choria.network.client_hosts = <%= $choria::broker::client_hosts.join(", ") %>
 <%   } -%>
 <% } -%>
+<% if $choria::broker::ssldir { -%>
+
+# Override ssldir for broker, if needed. This has different effects than setting this key in /etc/choria/plugins/choria.cfg
+plugin.choria.ssldir = <%= $choria::broker::ssldir %>
+<% } -%>
 
 <% if $choria::broker::federation_broker { -%>
 # The Choria Federation Broker routes isolated Collectives into a Federated Network


### PR DESCRIPTION
Setting ssldir independently for choria broker and choria server has a different net effect from setting this value in /etc/choria/plugins.d/choria.conf. This setting was added so it can be overridden in both.

This is important in situations where the puppetserver is installed in a nonstandard manner, for example when using puppetserver in containers, or with pupperware project.