### PR TITLE
(#172) Fix catalog for Windows nodes

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -10,6 +10,7 @@ choria::server_config:
   plugin.choria.ssldir: "C:/ProgramData/PuppetLabs/puppet/etc/ssl"
   plugin.choria.machine.store: "C:/ProgramData/choria/etc/machine"
   plugin.scout.overrides: "C:/ProgramData/choria/etc/overrides.json"
+  plugin.scout.goss.file: "C:/ProgramData/choria/etc/goss.yaml"
 
 choria::rubypath: "C:/Program Files/Puppet Labs/Puppet/puppet/bin/ruby.exe"
 choria::broker_config_file: "C:/ProgramData/choria/etc/broker.conf"


### PR DESCRIPTION
The custom Windows path for goss.yaml is missing from dde5a435cb4d7260e47130f0c2f34fee3e38b0f1 leading to catalog failure:

```
Failed to apply catalog: Parameter path failed on File[/etc/choria/goss.yaml]: File paths must be fully qualified, not '/etc/choria/goss.yaml' (file: /etc/puppetlabs/code/environments/romain/modules/choria/manifests/config.pp, line: 44)
```

This was discovered after updating the choria modules.