### PR TITLE
Change structure for nats adapter type

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Please review the [Data Adapters](https://choria.io/docs/adapters/) documentatio
 choria::broker::adapters:
   discover:
     stream:
-      type: "natsstream"
+      type: "nats_stream"
       clusterid: prod_stream
       topic: discovery
       workers: 10

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -24,7 +24,7 @@
 #    adapters => {
 #      discovery => {
 #        stream => {
-#          type => "natsstream",
+#          type => "nats_stream",
 #          servers => ["stan1:4222", "stan2:4222"],
 #          clusterid => "prod",
 #          topic => "discovery",

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -70,11 +70,15 @@ plugin.choria.middleware_hosts = <%= $choria::broker::collective_middleware_host
 plugin.choria.adapters = <%= $choria::broker::adapters.keys.sort.join(",") %>
 <%   $choria::broker::adapters.keys.sort.each |$adapter| { -%>
 <%      $choria::broker::adapters[$adapter].each |$section, $properties| { -%>
-<%        $properties.each |$key, $value| { -%>
-<%          if $value =~ Array { -%>
+<%        if $section == 'type' { -%>
+plugin.choria.adapter.<%= $adapter %>.<%= $section %> = <%= $properties %>
+<%        } else { -%>
+<%          $properties.each |$key, $value| { -%>
+<%            if $value =~ Array { -%>
 plugin.choria.adapter.<%= $adapter %>.<%= $section %>.<%= $key %> = <%= $value.join(", ") %>
-<%          } else { -%>
+<%            } else { -%>
 plugin.choria.adapter.<%= $adapter %>.<%= $section %>.<%= $key %> = <%= $value %>
+<%            } -%>
 <%          } -%>
 <%        } -%>
 <%      } -%>

--- a/types/adapters/natsstream.pp
+++ b/types/adapters/natsstream.pp
@@ -1,6 +1,6 @@
 type Choria::Adapters::NatsStream = Struct[{
+  type => Enum["nats_stream"],
   stream => Struct[{
-    type => Enum["natsstream"],
     servers => Array[String],
     clusterid => String,
     topic => String,


### PR DESCRIPTION
Set 'type' parameter in structure 'Choria::Adapters::NatsStream'
from 'stream' structure to level before stream structure.
Change 'type' parameter value in 'Choria::Adapters::NatsStream'
from 'natsstream' to 'nats_stream'.

Without this changes Choria-broker don't start with an ERROR:
'Failed to run Protocol Adapters: could not determine type
for adapter node_data, set plugin.choria.adapter.node_data.type'.

I've not checked jetstream adapter, may be 'Choria::Adapters::JetStream'
need some improvement too.