### PR TITLE
(#230) Add server_service_enable parameter

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -31,6 +31,7 @@ choria::status_write_interval: 30
 choria::package_name: "choria"
 choria::broker_service_name: "choria-broker"
 choria::server_service_name: "choria-server"
+choria::server_service_enable: true
 choria::identity: "%{trusted.certname}"
 choria::server: true
 choria::repo_gpgcheck: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@
 # @param package_name The package to install
 # @param broker_service_name The service name of the Choria Broker
 # @param server_service_name The service name of the Choria Server
+# @param server_service_enable Enable Choria Server at boot
 # @param identity The identity this server will use to determine SSL cert names etc
 # @param server To enable or disable the choria server
 # @param server_config Configuration for the Choria Server
@@ -57,6 +58,7 @@ class choria (
   String $package_name,
   String $broker_service_name,
   String $server_service_name,
+  Boolean $server_service_enable,
   String $identity,
   Boolean $server,
   Hash $server_config,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,7 +8,7 @@ class choria::service {
     if $choria::server {
       service{$choria::server_service_name:
         ensure => "running",
-        enable => true,
+        enable => $choria::server_service_enable,
       }
 
       if $choria::manage_mcollective {


### PR DESCRIPTION
Back when the service deployed was `mcollectived` with Puppet 5, we had some hosts like cluster RW hosts where the mcollective service does not come up on boot because that would cause RO compute nodes to also try and start the service which we don't want.  This adds that previous behavior back.