### PR TITLE
(choria-io#231) Fix $stream_store default value

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -73,7 +73,7 @@ class choria::broker (
   String $identity,
   Optional[Stdlib::Absolutepath] $ssldir = undef,
   Optional[Integer] $tls_timeout = undef,
-  Stdlib::Compat::Absolute_path $stream_store = "",
+  Optional[Stdlib::Compat::Absolute_path] $stream_store = undef,
   String $advisory_retention = "",
   String $event_retention = "",
   String $machine_retention = "",

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -58,7 +58,7 @@ plugin.choria.network.system.user = <%= $choria::broker::system_user %>
 plugin.choria.network.system.password = <%= $choria::broker::system_password %>
 <% } -%>
 
-<% if $choria::broker::stream_store != "" { -%>
+<% if $choria::broker::stream_store { -%>
 # Enables Choria Streaming for message persistence
 plugin.choria.network.stream.store = <%= $choria::broker::stream_store %>
 plugin.choria.network.stream.advisory_retention = <%= choria::broker::advisory_retention %>


### PR DESCRIPTION
When not explicitly set, `$stream_store` defaulted to an empty string which is not a valid `AbsoutePath`.

Make the parameter optional and change it's default value to `undef`.