### PR TITLE
(#238) Rename $choria::broker::leafnodes to leafnode_upstreams

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -50,7 +50,7 @@ choria::broker::federation_middleware_hosts: []
 choria::broker::collective_middleware_hosts: []
 choria::broker::client_hosts: []
 choria::broker::adapters: {}
-choria::broker::leafnodes: {}
+choria::broker::leafnode_upstreams: {}
 choria::broker::identity: "%{trusted.certname}"
 choria::broker::cluster_peer_port: 0
 choria::broker::leafnode_port: 0

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -50,7 +50,7 @@
 # @param leafnode_port Port leafnode connections will be accepted on
 # @param client_hosts Whitelist of clients that are allowed to connect to broker
 # @param adapters Data adapters to configure
-# @param leafnodes LEafnode connections to configure
+# @param leafnode_upstreams Leafnode connections to configure
 # @param tls_timeout TLS Handshake timeout (in seconds)
 # @param identity The identity this broker will use to determine SSL cert names etc
 # @param stream_store Enables Streaming and store data in this path
@@ -74,7 +74,7 @@ class choria::broker (
   Array[String] $collective_middleware_hosts,
   Array[String] $client_hosts,
   Choria::Adapters $adapters,
-  Choria::Leafnodes $leafnodes,
+  Choria::Leafnodes $leafnode_upstreams,
   String $identity,
   Optional[Stdlib::Absolutepath] $ssldir = undef,
   Optional[Integer] $tls_timeout = undef,

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -106,32 +106,32 @@ plugin.choria.adapter.<%= $adapter %>.<%= $section %>.<%= $key %> = <%= $value %
 # Other Choria Network Brokers in branch offices can connect here using Leafnode protocols
 plugin.choria.network.leafnode_port = <%= $choria::broker::leafnode_port %>
 <% } -%>
-<% unless $choria::broker::leafnodes.empty { -%>
+<% unless $choria::broker::leafnode_upstreams.empty { -%>
 
 # Leafnodes configure links to Choria networks suitable for branch networks
-plugin.choria.network.leafnode_remotes = <%= $choria::broker::leafnodes.keys.sort.join(",") %>
-<%   $choria::broker::leafnodes.keys.sort.each |$leaf| { -%>
-plugin.choria.network.leafnode_remote.<%= $leaf %>.url = <%= $choria::broker::leafnodes[$leaf]["url"] %>
-<%     if $choria::broker::leafnodes[$leaf]["account"] {-%>
-plugin.choria.network.leafnode_remote.<%= $leaf %>.account = <%= $choria::broker::leafnodes[$leaf]["account"] %>
+plugin.choria.network.leafnode_remotes = <%= $choria::broker::leafnode_upstreams.keys.sort.join(",") %>
+<%   $choria::broker::leafnode_upstreams.keys.sort.each |$leaf| { -%>
+plugin.choria.network.leafnode_remote.<%= $leaf %>.url = <%= $choria::broker::leafnode_upstreams[$leaf]["url"] %>
+<%     if $choria::broker::leafnode_upstreams[$leaf]["account"] {-%>
+plugin.choria.network.leafnode_remote.<%= $leaf %>.account = <%= $choria::broker::leafnode_upstreams[$leaf]["account"] %>
 <%     } -%>
-<%     if $choria::broker::leafnodes[$leaf]["credentials"] {-%>
-plugin.choria.network.leafnode_remote.<%= $leaf %>.credentials = <%= $choria::broker::leafnodes[$leaf]["credentials"] %>
+<%     if $choria::broker::leafnode_upstreams[$leaf]["credentials"] {-%>
+plugin.choria.network.leafnode_remote.<%= $leaf %>.credentials = <%= $choria::broker::leafnode_upstreams[$leaf]["credentials"] %>
 <%     } -%>
-<%     if $choria::broker::leafnodes[$leaf]["tls"] { -%>
-<%       if $choria::broker::leafnodes[$leaf]["tls"]["cert"] { -%>
-plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.cert = <%= $choria::broker::leafnodes[$leaf]["tls"]["cert"] %>
+<%     if $choria::broker::leafnode_upstreams[$leaf]["tls"] { -%>
+<%       if $choria::broker::leafnode_upstreams[$leaf]["tls"]["cert"] { -%>
+plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.cert = <%= $choria::broker::leafnode_upstreams[$leaf]["tls"]["cert"] %>
 <%       } -%>
-<%       if $choria::broker::leafnodes[$leaf]["tls"]["key"] { -%>
-plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.key = <%= $choria::broker::leafnodes[$leaf]["tls"]["key"] %>
+<%       if $choria::broker::leafnode_upstreams[$leaf]["tls"]["key"] { -%>
+plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.key = <%= $choria::broker::leafnode_upstreams[$leaf]["tls"]["key"] %>
 <%       } -%>
-<%       if $choria::broker::leafnodes[$leaf]["tls"]["ca"] { -%>
-plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.ca = <%= $choria::broker::leafnodes[$leaf]["tls"]["ca"] %>
+<%       if $choria::broker::leafnode_upstreams[$leaf]["tls"]["ca"] { -%>
+plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.ca = <%= $choria::broker::leafnode_upstreams[$leaf]["tls"]["ca"] %>
 <%       } -%>
-<%       if $choria::broker::leafnodes[$leaf]["tls"]["verify"] != "" and $choria::broker::leafnodes[$leaf]["tls"]["verify"] == false { -%>
+<%       if $choria::broker::leafnode_upstreams[$leaf]["tls"]["verify"] != "" and $choria::broker::leafnode_upstreams[$leaf]["tls"]["verify"] == false { -%>
 plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.verify = false
 <%       } -%>
-<%       if $choria::broker::leafnodes[$leaf]["tls"]["disable"] != "" and $choria::broker::leafnodes[$leaf]["tls"]["disable"] == true { -%>
+<%       if $choria::broker::leafnode_upstreams[$leaf]["tls"]["disable"] != "" and $choria::broker::leafnode_upstreams[$leaf]["tls"]["disable"] == true { -%>
 plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.disable = true
 <%       } -%>
 <%     } -%>


### PR DESCRIPTION
This parameter is used to tell a leaf node how to connect to the rest of
the middleware, change the name that could misleading be interpreted as
a list of leaf nodes allowed to connect to a broker.