### PR TITLE
Broker parameters for anonymous TLS to leaf node

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -51,6 +51,9 @@
 # @param client_hosts Whitelist of clients that are allowed to connect to broker
 # @param adapters Data adapters to configure
 # @param leafnode_upstreams Leafnode connections to configure
+# @param client_anon_tls Use anonymous TLS for client connections (disables verification)
+# @param request_signing_certificate The public certificate of the key used to sign the JWTs in the Signing Service
+# @param deny_server_connections Set ACLs denying server connections to this broker
 # @param tls_timeout TLS Handshake timeout (in seconds)
 # @param identity The identity this broker will use to determine SSL cert names etc
 # @param stream_store Enables Streaming and store data in this path
@@ -69,6 +72,9 @@ class choria::broker (
   Integer $cluster_peer_port,
   Integer $stats_port,
   Integer $leafnode_port,
+  Boolean $client_anon_tls = false,
+  Optional[Stdlib::AbsolutePath] $request_signing_certificate = undef,
+  Boolean $deny_server_connections = false,
   Array[String] $network_peers,
   Array[String] $federation_middleware_hosts,
   Array[String] $collective_middleware_hosts,

--- a/spec/classes/broker_spec.rb
+++ b/spec/classes/broker_spec.rb
@@ -1,23 +1,80 @@
 require "spec_helper"
 
-describe 'choria' do
+describe 'choria::broker' do
 
   let :node do
     "rspec.puppet.com"
   end
 
-  let :params do
-    { manage_mcollective: false }
+  let :pre_condition  do
+    '
+    class{choria:
+      manage_mcollective => false,
+    }
+    '
   end
-
 
   on_supported_os.each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts
       end
+      it { is_expected.to compile.with_all_deps }
       context 'with all defaults' do
-        it { is_expected.to compile.with_all_deps }
+        case facts[:os]['family']
+        when 'windows'
+          it { is_expected.to contain_file('C:/ProgramData/choria/etc/broker.conf') }
+        when 'FreeBSD'
+          it { is_expected.to contain_file('/usr/local/etc/choria/broker.conf') }
+        else
+          it { is_expected.to contain_file('/etc/choria/broker.conf').without_content(%r{plugin.choria.network.client_anon_tls}) }
+          it { is_expected.to contain_file('/etc/choria/broker.conf').without_content(%r{plugin.choria.security.request_signing_certificate}) }
+          it { is_expected.to contain_file('/etc/choria/broker.conf').without_content(%r{plugin.choria.network.deny_server_connections}) }
+        end
+      end
+
+      context 'with booleans set false' do
+        let :params do
+          {client_anon_tls: false, deny_server_connections: false}
+        end
+        case facts[:os]['family']
+        when 'FreeBSD'
+          it { is_expected.to contain_file('/usr/local/etc/choria/broker.conf') }
+        when 'windows'
+          it { is_expected.to contain_file('C:/ProgramData/choria/etc/broker.conf') }
+        else
+          it { is_expected.to contain_file('/etc/choria/broker.conf').without_content(%r{plugin.choria.network.client_anon_tls}) }
+          it { is_expected.to contain_file('/etc/choria/broker.conf').without_content(%r{plugin.choria.network.deny_server_connections}) }
+        end
+      end
+
+      context 'with booleans set true' do
+        let :params do
+          {client_anon_tls: true, deny_server_connections: true}
+        end
+        case facts[:os]['family']
+        when 'FreeBSD'
+          it { is_expected.to contain_file('/usr/local/etc/choria/broker.conf') }
+        when 'windows'
+          it { is_expected.to contain_file('C:/ProgramData/choria/etc/broker.conf') }
+        else
+          it { is_expected.to contain_file('/etc/choria/broker.conf').with_content(%r{^plugin.choria.network.client_anon_tls = true$}) }
+          it { is_expected.to contain_file('/etc/choria/broker.conf').with_content(%r{^plugin.choria.network.deny_server_connections = true$}) }
+        end
+      end
+
+      context 'with strings set' do
+        let :params do
+          {request_signing_certificate: '/tmp/foo.pem'}
+        end
+        case facts[:os]['family']
+        when 'FreeBSD'
+          it { is_expected.to contain_file('/usr/local/etc/choria/broker.conf') }
+        when 'windows'
+          it { is_expected.to contain_file('C:/ProgramData/choria/etc/broker.conf') }
+        else
+          it { is_expected.to contain_file('/etc/choria/broker.conf').with_content(%r{^plugin.choria.security.request_signing_certificate = /tmp/foo.pem$}) }
+        end
       end
     end
   end

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -137,3 +137,13 @@ plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.disable = true
 <%     } -%>
 <%   } -%>
 <% } -%>
+
+<% if $choria::broker::client_anon_tls { -%>
+plugin.choria.network.client_anon_tls = true
+<% } -%>
+<% if $choria::broker::request_signing_certificate { -%>
+plugin.choria.security.request_signing_certificate = <%= $choria::broker::request_signing_certificate %>
+<% } -%>
+<% if $choria::broker::deny_server_connections { -%>
+plugin.choria.network.deny_server_connections = true
+<% } -%>


### PR DESCRIPTION
Three new parameters for choria::broker

* client_anon_tls
* request_signing_certificate
* deny_server_connections

to set each of

* plugin.choria.network.client_anon_tls
* plugin.choria.security.request_signing_certificate
* plugin.choria.network.deny_server_connections

by default there is no change to the broker.conf