### PR TITLE
(misc) Use EL8 repo for Fedora

### DIFF
--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,2 +1,2 @@
 ---
-choria::version: "0.22.0-1.el%{facts.os.release.major}"
+choria::version: "0.22.0"

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,6 +16,8 @@ class choria::repo (
       $release = '7'
     } elsif $facts['os']['name'] == 'Amazon' {
       $release = '6'
+    } elsif $facts['os']['name'] == 'Fedora' {
+      $release = '8'
     } elsif versioncmp($facts['os']['release']['major'], '6') < 0 {
       fail("Choria Repositories are only supported for RHEL/CentOS 6 or newer releases")
     } else {

--- a/metadata.json
+++ b/metadata.json
@@ -48,6 +48,14 @@
       ]
     },
     {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "32",
+        "33",
+        "34"
+      ]
+    },
+    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
         "11 SP1",


### PR DESCRIPTION
The logic that was removed in https://github.com/choria-io/puppet-choria/commit/17f3ba5573107dea6bfb6f1bc7418731c25cc78d also removed support for Fedora as a side-effect.  This explicitly adds support for Fedora (by mapping it to the EL8 repo).