### PR TITLE
fixing syntax issues

### DIFF
--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -79,8 +79,8 @@ plugin.choria.network.stream.machine_replicas = <%= $choria::broker::machine_rep
 # Enables accepting unverified TLS connections for provisioning
 # https://choria.io/blog/post/2021/08/13/secure_and_ha_provisioning/
 
-plugin.choria.network.provisioning.signer_cert = <%= $choria::broker::config_dir $>/provisioner-signer-certificate.pem
-plugin.choria.network.provisioning.client_password = <%= $choria::broker::provisioner_password $>
+plugin.choria.network.provisioning.signer_cert = <%= $choria::broker::config_dir %>/provisioner-signer-certificate.pem
+plugin.choria.network.provisioning.client_password = <%= $choria::broker::provisioner_password %>
 <% } -%>
 <% if $choria::broker::federation_broker { -%>
 


### PR DESCRIPTION
Was receiving this error:

`Error: Facter: error while resolving custom fact "docker": undefined method match?' for nil:NilClass
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, epp(): Invalid EPP: Syntax error at '' (file: /etc/puppetlabs/code/environments/production/modules/choria/templates/broker.cfg.epp, line: 82, column: 82) (file: /etc/puppetlabs/code/environments/production/modules/choria/manifests/broker/config.pp, line: 33, column: 16) on node admin11.riskiq`

Assuming the $ at the end of variables were meant to be %.