### PR TITLE
(#267) Arch Linux: Use /usr/bin/ruby-2.7 instead of default Ruby 3

### DIFF
--- a/data/os/Archlinux.yaml
+++ b/data/os/Archlinux.yaml
@@ -1,2 +1,3 @@
 ---
 choria::manage_package_repo: false
+choria::rubypath: /usr/bin/ruby-2.7


### PR DESCRIPTION
closes https://github.com/choria-io/puppet-choria/issues/267