### PR TITLE
(#281) Arch Linux: Switch from Ruby 2.7 to 3

### DIFF
--- a/data/os/Archlinux.yaml
+++ b/data/os/Archlinux.yaml
@@ -1,4 +1,4 @@
 ---
 choria::manage_package_repo: false
-choria::rubypath: /usr/bin/ruby-2.7
+choria::rubypath: /usr/bin/ruby
 choria::package_name: choria-io


### PR DESCRIPTION
With a recent[0] change Arch Linux switched from Puppet 6 with Ruby 2.7
to Puppet 7 with Ruby 3. Choria needs to use the same Ruby path

[0]:
https://github.com/archlinux/svntogit-community/commit/883d8294caf7ad32e0d420a91d3adfcedd2ecdba#diff-3e341d2d9c67be01819b25b25d5e53ea3cdf3a38d28846cda85a195eb9b7203a