### PR TITLE
(#292) add package_source

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -23,3 +23,4 @@ choria::mcollective_config_dir: "C:/ProgramData/choria/etc"
 choria::config_user: ~
 choria::config_group: ~
 choria::manage_package_repo: false
+choria::package_name: Choria Orchestrator

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@
 # @param nightly_repo Install the nightly package repo as well as the release one
 # @param kv_buckets Hash of choria_kv_bucket resources for a node, ideal for use using Hiera
 # @param governors Hash of choria_governor resources for a node, ideal for use using Hiera
+# @param package_source The package source location
 class choria (
   Boolean $manage_package,
   Boolean $manage_service,
@@ -76,6 +77,7 @@ class choria (
   Boolean $manage_mcollective = true,
   Choria::KVBuckets $kv_buckets = {},
   Choria::Governors $governors = {},
+  Optional[String] $package_source = undef,
 ) {
   if $manage_package_repo {
     class{"choria::repo":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,8 @@ class choria::install {
     }
 
     package{$choria::package_name:
-      ensure => $version
+      ensure => $version,
+      source => $choria::package_source,
     }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -308,6 +308,30 @@ describe 'choria' do
         it { is_expected.to contain_class("choria::service_disable") }
         it { is_expected.not_to contain_class("choria::service") }
       end
+
+      context 'with package_source and manage_package' do
+        let :params do
+          {
+            manage_package: true,
+            manage_mcollective: false,
+            package_source: 'C:/choria.msi'
+          }
+        end
+
+        _package = case facts[:os]['family']
+                   when 'Archlinux'
+                     'choria-io'
+                  when 'windows'
+                    'Choria Orchestrator'
+                  else
+                    'choria'
+                  end
+        it do
+          is_expected.to contain_package(_package).with(
+            source: 'C:/choria.msi'
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This feature can be use for msi installation:

```
file { 'C:\choria.msi':
  ensure => file,
  source => "https://github.com/choria-io/go-choria/releases/download/v0.24.1/Choria-0.24.1.msi", 
}

-> class { 'choria':
  package_source => 'C:\choria.msi',
  manage_package_repo => false,
  manage_package => true,
  manage_service => true,
}
```