### PR TITLE
(choria-io/mcorpc-ruby-support#179) Allow access to Choria::TaskResults#bolt_task_result

### DIFF
--- a/lib/puppet/datatypes/choria/taskresult.rb
+++ b/lib/puppet/datatypes/choria/taskresult.rb
@@ -11,6 +11,7 @@ Puppet::DataTypes.create_type("Choria::TaskResult") do
       type => Callable[[], String[1]],
       "[]" => Callable[[String[1]], Data],
       "value" => Callable[[], Data]
+      bolt_task_result => Callable[[], Data],
     }
   PUPPET
 


### PR DESCRIPTION
This is a companion PR of https://github.com/choria-io/mcorpc-ruby-support/pull/178