### PR TITLE
(#298) Unbreak for systems without IPv6

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -40,7 +40,7 @@ choria::broker::network_broker: true
 choria::broker::federation_broker: false
 choria::broker::federation_cluster: "%{::environment}"
 choria::broker::listen_address: "::"
-choria::broker::stats_listen_address: "::1"
+choria::broker::stats_listen_address: "localhost"
 choria::broker::client_port: 4222
 choria::broker::websocket_port: 0
 choria::broker::stats_port: 8222


### PR DESCRIPTION
When starting on a system without IPv6, choria cannot bind on address
::1 and exit.  Replace the loopback IP address with the name `localhost`
and allow the go library to resolve the IP address corresponding to it
to bind to.

The go library seems to only find and une a single IP address.  For now
assume this is not a bloker.
