### PR TITLE
(#320) allow plugin.choria.network.gateway_name to be set

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -39,6 +39,7 @@ choria::config_group: "root"
 choria::broker::network_broker: true
 choria::broker::federation_broker: false
 choria::broker::federation_cluster: "%{::environment}"
+choria::broker::cluster_name: ~
 choria::broker::manage_service: true
 choria::broker::listen_address: "::"
 choria::broker::stats_listen_address: "localhost"

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -62,10 +62,12 @@
 # @param system_password Password to use for access to the System account
 # @param provisioner_password The Password the Choria Provisioner needs to present
 # @param provisioning_signer_source A Puppet source where the public used to sign provisioning.jwt is found
+# @param $cluster_name Configures a unique location specific name, use when establishing leafnodes to a central network
 class choria::broker (
   Boolean $network_broker,
   Boolean $federation_broker,
   Optional[String] $federation_cluster,
+  Optional[String] $cluster_name,
   Boolean $manage_service,
   Stdlib::Host $listen_address,
   Stdlib::Host $stats_listen_address,

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -153,3 +153,9 @@ plugin.choria.network.leafnode_remote.<%= $leaf %>.tls.disable = true
 <%     } -%>
 <%   } -%>
 <% } -%>
+
+<% if $choria::broker::cluster_name { -%>
+# A unique name for this network, if connecting to a remote cluster as a
+# leafnode this name should uniquely identify this site
+plugin.choria.network.gateway_name = <%= $choria::broker::cluster_name %>
+<% } -%>


### PR DESCRIPTION
Recent NATS Server versions require unique cluster names for leafnodes connecting to a cluster.

We default to CHORIA for all cluster names, this used to work but failed in the previous choria release.

Those wishing to use leafnodes to a Choria cluster would need to set this variable to a unique name

Signed-off-by: R.I.Pienaar <rip@devco.net>