### PR TITLE
(misc) Update stdlib requirementx

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,7 +42,7 @@ class choria::config {
 
   $choria::scout_gossfile.each |$target, $gossfile| {
     file{$target:
-      content => $gossfile.to_yaml,
+      content => $gossfile.stdlib::to_yaml,
       owner   => $choria::config_user,
       group   => $choria::config_group,
       mode    => "0755",
@@ -51,7 +51,7 @@ class choria::config {
 
   if "plugin.scout.overrides" in $choria::server_config {
     file{$choria::server_config["plugin.scout.overrides"]:
-      content => $choria::scout_overrides.to_json,
+      content => $choria::scout_overrides.stdlib::to_json,
       owner   => $choria::config_user,
       group   => $choria::config_group,
       mode    => "0755",

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/choria-io/puppet-choria",
   "issues_url": "https://github.com/choria-io/puppet-choria/issues",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.24.0 < 9.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 9.0.0 < 10.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 4.5.1 < 10.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 4.0.0 < 8.0.0" },
     { "name": "choria/mcollective_choria", "version_requirement": ">= 0.21.5 < 2.0.0" },

--- a/plans/tasks/download_files.pp
+++ b/plans/tasks/download_files.pp
@@ -20,7 +20,7 @@ plan choria::tasks::download_files(
     "properties"       => {
       "environment"    => "production",
       "task"           => $task,
-      "files"          => $files.to_json
+      "files"          => $files.stdlib::to_json
     }
   )
 }

--- a/plans/tasks/run.pp
+++ b/plans/tasks/run.pp
@@ -57,8 +57,8 @@ plan choria::tasks::run(
     "silent"           => $silent,
     "properties"       => {
       "task"           => $task,
-      "files"          => $metadata["files"].to_json,
-      "input"          => $inputs.to_json
+      "files"          => $metadata["files"].stdlib::to_json,
+      "input"          => $inputs.stdlib::to_json
     } + $run_as_property
   )
 }


### PR DESCRIPTION
In order to avoid function name collision, the puppet community is moving away from unscoped functions in modules so that only Puppet provide functions without an explicit scope.

stdlib 9.0.0 deprecate all unscoped Puppet 4 functions and provide them with the `stdlib::` scope.  While the unscoped function still exist and default to calling the scoped function, Puppet 8 enabled strict mode by default in an effort to limit the accumulation of cruft in the end users control-repos.  That mean that if we enable the latest stdlib, we must also increase the minimum version to make sure the scoped versions of the functions are available.

Fixes #326 