### PR TITLE
(#329) Allow environment other than production for playbook

### DIFF
--- a/plans/tasks/download_files.pp
+++ b/plans/tasks/download_files.pp
@@ -3,11 +3,13 @@
 # @param nodes The nodes to download onto
 # @param files The files section of the task metadata
 # @param task The name of the task
+# @param tasks_environment The environment to find tasks
 # @return [Choria::TaskResults]
 plan choria::tasks::download_files(
   String $task,
   Array[Hash] $files,
-  Choria::Nodes $nodes
+  Choria::Nodes $nodes,
+  String[1] $tasks_environment = "production",
 ) {
   info("Downloading files for task '${task}' onto ${nodes.size} nodes")
 
@@ -18,7 +20,7 @@ plan choria::tasks::download_files(
     "batch_sleep_time" => 1,
     "silent"           => true,
     "properties"       => {
-      "environment"    => "production",
+      "environment"    => $tasks_environment,
       "task"           => $task,
       "files"          => $files.to_json
     }

--- a/plans/tasks/run.pp
+++ b/plans/tasks/run.pp
@@ -15,6 +15,7 @@
 # @param silent Surpress logging of individual node results
 # @param batch_size When not 0, run the task on nodes in batches
 # @params batch_sleep_time How long to sleep between batches
+# @param tasks_environment The environment to find tasks
 plan choria::tasks::run(
   Choria::Nodes $nodes,
   String $task,
@@ -23,16 +24,18 @@ plan choria::tasks::run(
   Boolean $silent = false,
   Integer $batch_size = 0,
   Integer $batch_sleep_time = 2,
-  Optional[String[1]] $run_as = undef
+  Optional[String[1]] $run_as = undef,
+  String[1] $tasks_environment = "production",
 ) {
   $metadata = choria::tasks::metadata($task)
 
   choria::tasks::validate_input($inputs, $metadata)
 
   choria::run_playbook("choria::tasks::download_files",
-    "nodes" => $nodes,
-    "task"  => $task,
-    "files" => $metadata["files"]
+    "nodes"       => $nodes,
+    "task"        => $task,
+    "files"       => $metadata["files"],
+    "environment" => $tasks_environment,
   )
 
   if $background {


### PR DESCRIPTION
Allow an environment other than production to be used to pull tasks. This allows for things like r10k synced branches to be tested and validated before being promoted to production