### PR TITLE
(#339) Use modern APT keyrings on Debian family

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -84,7 +84,7 @@ class choria::repo (
       release       => $repo_os_name,
       repos         => $release,
       key           => {
-        id     => "3DE1895F7B983F9B22DAF64030BC99C1AAEEF24D",
+        name   => "choria.asc",
         source => "https://choria.io/RELEASE-GPG-KEY"
       },
       architecture  => $facts["os"]["architecture"],

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/choria-io/puppet-choria/issues",
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 9.0.0 < 10.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 4.5.1 < 10.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 9.2.0 < 10.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 9.0.0 < 10.0.0" },
     { "name": "choria/mcollective_choria", "version_requirement": ">= 0.22.0 < 2.0.0" },
     { "name": "choria/mcollective", "version_requirement": ">= 0.14.4 < 2.0.0" },


### PR DESCRIPTION
This makes use of puppetlabs/puppetlabs-apt#1128 to store the public key
in `/etc/apt/keyrings` and add a `signed-by` option to the
`sources.list.d` entry.
