### PR TITLE
(#350) v2 provisioning relies on a JWT for auth

### DIFF
--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -76,13 +76,11 @@ plugin.choria.network.stream.event_replicas = <%= $choria::broker::event_replica
 plugin.choria.network.stream.machine_retention = <%= $choria::broker::machine_retention %>
 plugin.choria.network.stream.machine_replicas = <%= $choria::broker::machine_replicas %>
 <% } -%>
-<% if $choria::broker::provisioner_password != "" and $choria::broker::provisioning_signer_source != "" { -%>
-
-# Enables accepting unverified TLS connections for provisioning
-# https://choria.io/blog/post/2021/08/13/secure_and_ha_provisioning/
-
-plugin.choria.network.provisioning.signer_cert = <%= $choria::broker::config_dir %>/provisioner-signer-certificate.pem
+<% if $choria::broker::provisioner_password != ""{ -%>
 plugin.choria.network.provisioning.client_password = <%= $choria::broker::provisioner_password %>
+<%   if $choria::broker::provisioning_signer_source != "" { -%>
+plugin.choria.network.provisioning.signer_cert = <%= $choria::broker::config_dir %>/provisioner-signer-certificate.pem
+<%   } -%>
 <% } -%>
 <% if $choria::broker::federation_broker { -%>
 


### PR DESCRIPTION
So we allow provisioner_password to be set without setting signer_cert but set that when supplied for backward compat