### PR TITLE
(#352) Allow choria::task::run to catch errors

### DIFF
--- a/plans/tasks/download_files.pp
+++ b/plans/tasks/download_files.pp
@@ -4,12 +4,14 @@
 # @param files The files section of the task metadata
 # @param task The name of the task
 # @param tasks_environment The environment to find tasks
+# @param catch_errors Whether to catch errors
 # @return [Choria::TaskResults]
 plan choria::tasks::download_files(
   String $task,
   Array[Hash] $files,
   Choria::Nodes $nodes,
   String[1] $tasks_environment = "production",
+  Optional[Boolean] $catch_errors = undef,
 ) {
   info("Downloading files for task '${task}' onto ${nodes.size} nodes")
 
@@ -19,6 +21,7 @@ plan choria::tasks::download_files(
     "batch_size"       => 50,
     "batch_sleep_time" => 1,
     "silent"           => true,
+    "_catch_errors"    => $catch_errors,
     "properties"       => {
       "environment"    => $tasks_environment,
       "task"           => $task,

--- a/plans/tasks/run.pp
+++ b/plans/tasks/run.pp
@@ -16,6 +16,7 @@
 # @param batch_size When not 0, run the task on nodes in batches
 # @params batch_sleep_time How long to sleep between batches
 # @param tasks_environment The environment to find tasks
+# @param catch_errors Whether to catch errors
 plan choria::tasks::run(
   Choria::Nodes $nodes,
   String $task,
@@ -26,6 +27,7 @@ plan choria::tasks::run(
   Integer $batch_sleep_time = 2,
   Optional[String[1]] $run_as = undef,
   String[1] $tasks_environment = "production",
+  Optional[Boolean] $catch_errors = undef,
 ) {
   $metadata = choria::tasks::metadata($task, $tasks_environment)
 
@@ -36,6 +38,7 @@ plan choria::tasks::run(
     "task"              => $task,
     "files"             => $metadata["files"],
     "tasks_environment" => $tasks_environment,
+    "catch_errors"      => $catch_errors,
   )
 
   if $background {
@@ -58,6 +61,7 @@ plan choria::tasks::run(
     "batch_size"       => $batch_size,
     "batch_sleep_time" => $batch_sleep_time,
     "silent"           => $silent,
+    "_catch_errors"    => $catch_errors,
     "properties"       => {
       "task"           => $task,
       "files"          => $metadata["files"].stdlib::to_json,


### PR DESCRIPTION
If a playbook wishes to handle task errors, the tasks themselves need to also catch errors

Fixes #352