### PR TITLE
(#356) Look additionally for a puppet config

### DIFF
--- a/lib/puppet/provider/choria_governor/choria_governor.rb
+++ b/lib/puppet/provider/choria_governor/choria_governor.rb
@@ -25,12 +25,16 @@ class Puppet::Provider::ChoriaGovernor::ChoriaGovernor < Puppet::ResourceApi::Si
   def config_file
     paths = if Process.uid == 0
       [
+        "/etc/choria/puppet.conf",
         "/etc/choria/server.conf",
+        "/usr/local/etc/choria/puppet.conf",
         "/usr/local/etc/choria/server.conf",
       ]
     else
       [
+        "/etc/choria/puppet.conf",
         "/etc/choria/client.conf",
+        "/usr/local/etc/choria/puppet.conf",
         "/usr/local/etc/choria/client.conf",
       ]
     end

--- a/lib/puppet/provider/choria_kv_bucket/choria_kv_bucket.rb
+++ b/lib/puppet/provider/choria_kv_bucket/choria_kv_bucket.rb
@@ -25,12 +25,16 @@ class Puppet::Provider::ChoriaKvBucket::ChoriaKvBucket < Puppet::ResourceApi::Si
   def config_file
     paths = if Process.uid == 0
       [
+        "/etc/choria/puppet.conf",
         "/etc/choria/server.conf",
+        "/usr/local/etc/choria/puppet.conf",
         "/usr/local/etc/choria/server.conf",
       ]
     else
       [
+        "/etc/choria/puppet.conf",
         "/etc/choria/client.conf",
+        "/usr/local/etc/choria/puppet.conf",
         "/usr/local/etc/choria/client.conf",
       ]
     end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -132,7 +132,7 @@ class choria::config {
       require => Class["choria::install"],
     }
 
-    if $choria::server {
+    if $choria::manage_server_config and $choria::server {
       File[$choria::server_provisioning_token_file] ~> Class["choria::service"]
     }
   }


### PR DESCRIPTION
This allows the gov and kv providers to have specific auth setup which is required for v2 networks.

Also fixes a bug with relationships when not managing the config