### PR TITLE
(#362) I want to configure file auth in broker.conf

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -63,8 +63,9 @@
 # @param provisioner_password The Password the Choria Provisioner needs to present
 # @param provisioning_signer_source A Puppet source where the public used to sign provisioning.jwt is found
 # @param $cluster_name Configures a unique location specific name, use when establishing leafnodes to a central network
-# @param $issuer Defines a Choria Protocol version 2 Issuer
-# @param $choria_security Configures the Choria Protocol version 2 security plugin
+# @param issuer Defines a Choria Protocol version 2 Issuer
+# @param choria_security Configures the Choria Protocol version 2 security plugin
+# @param file_security Configures file authentication
 class choria::broker (
   Boolean $network_broker,
   Boolean $federation_broker,
@@ -100,6 +101,7 @@ class choria::broker (
   Optional[Stdlib::Absolutepath] $stream_store = undef,
   Optional[Choria::Issuer] $issuer = undef,
   Optional[Choria::ChoriaSecurity] $choria_security = undef,
+  Optional[Choria::FileSecurity] $file_security = undef,
 ) {
   require choria
 

--- a/templates/broker.cfg.epp
+++ b/templates/broker.cfg.epp
@@ -175,3 +175,10 @@ plugin.security.choria.ca = <%= $choria::broker::choria_security["ca"] %>
 <%   } -%>
 <% } -%>
 
+<% if $choria::broker::file_security { -%>
+# Choria file provider configuration
+plugin.security.provider = file
+plugin.security.file.certificate = <%= $choria::broker::file_security["certificate"] %>
+plugin.security.file.key = <%= $choria::broker::file_security["key"] %>
+plugin.security.file.ca = <%= $choria::broker::file_security["ca"] %>
+<% } -%>

--- a/types/filesecurity.pp
+++ b/types/filesecurity.pp
@@ -1,0 +1,5 @@
+type Choria::FileSecurity = Struct[{
+  "certificate" => Stdlib::Absolutepath,
+  "key"         => Stdlib::Absolutepath,
+  "ca"          => Stdlib::Absolutepath,
+}]


### PR DESCRIPTION
Following this doc, I am trying to set up file authentication with custom paths in broker.conf:

https://choria.io/docs/concepts/security/#custom-certificates

However, when I try to set `$choria::broker::choria_security` with just `ca`, `certificate` and `key`, Puppet fails with the error:

```
parameter 'choria_security' expects a value for key 'token_file'
  parameter 'choria_security' expects a value for key 'seed_file' (file: /etc/puppetlabs/code-versions/blah/blah/choria.pp, line: 21, column: 5) on node blah.com
```

And more! the security provider is hardcoded to `choria` and depends on `$choria::broker::issuer`, which I don't want to set up.

In order to support file auth in broker.conf, my MR added these changes:
- Add Optional to all of the attributes in the type `Choria::ChoriaSecurity`, 
- Add an `else` to the template so if `$choria::broker::choria_security` is declared but `$choria::broker::issuer` isn't, it'll configure the file auth.

Here are the tests using my fork:

```
# Hiera file
choria::broker::choria_security:
  "ca": '/etc/choria/ssl/bundle.pem'
  "certificate": "/etc/choria/ssl/%{facts.networking.fqdn}.pem"
  "key": "/etc/choria/ssl/private_keys/%{facts.networking.fqdn}.pem"
```

```
# Puppet run
+++ /tmp/puppet-file20250319-1526986-yv2eu9	2025-03-19 23:18:29.925271673 +0000
@@ -31,3 +31,8 @@
 plugin.choria.network.peers = ***
 
 
+# Choria SSL certificates configuration
+plugin.security.provider = file
+plugin.security.file.certificate = /etc/puppetlabs/puppet/ssl/certs/blah.pem
+plugin.security.file.key = /etc/puppetlabs/puppet/ssl/private_keys/blah.pem
+plugin.security.file.ca = /etc/choria/ssl/bundle.pem

Notice: /Stage[main]/Choria::Broker::Config/File[/etc/choria/broker.conf]/content: content changed '{sha256}5b1ac53e0b185ac0eb07a546f08715466f5d6347cee6634bb1bc138542367' to '{sha256}4022f4844166dd94a5fd787f8bf87959154fd878d41bc9dc4ce84dfa7d4a7'
```

```
# broker.conf
[...]
plugin.security.provider = file
plugin.security.file.certificate = /etc/puppetlabs/puppet/ssl/certs/blah.pem
plugin.security.file.key = /etc/puppetlabs/puppet/ssl/private_keys/blah.pem
plugin.security.file.ca = /etc/choria/ssl/bundle.pem
```

I'm happy to discuss any other ways to go around this, as I don't have the full picture of what this could possibly affect as I don't use JWT.