### PR TITLE
(misc) puppet-choria works fine on Ubuntu 24.04 with OpenVox 8 and puppetlabs/apt 10.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A modern Orchestration Engine with roots in The Marionette Collective.  Please r
 
 ### Package Repo and Basic Installation
 
-At present RHEL 7 and 8, Debian Stretch, Buster and Bullseye and Ubuntu Xenial, Bionic and Focal are supported, the repository also include packages for other tools like our Stream Replicator etc.
+At present RHEL 7 and 8, Debian Stretch, Buster and Bullseye and Ubuntu Mantic and Noble are supported. The repositories also include packages for other tools like our Stream Replicator etc.
 
-It's best configured using Hiera, to install the YUM Repository and install a particular version with some basic adjustments this will be enough.
+It's best configured using Hiera; to install the YUM/APT Repository and install a particular version with some basic adjustments this will be enough.
 
 ```yaml
 choria::manage_package_repo: true

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/choria-io/puppet-choria/issues",
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 9.0.0 < 10.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 9.2.0 < 10.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 9.2.0 < 11.0.0" },
     { "name": "puppetlabs/concat", "version_requirement": ">= 9.0.0 < 10.0.0" },
     { "name": "choria/mcollective_choria", "version_requirement": ">= 0.22.2 < 2.0.0" },
     { "name": "choria/mcollective", "version_requirement": ">= 0.14.6 < 2.0.0" },


### PR DESCRIPTION
The only thing I needed to change was the maximum allowed version of puppetlabs/apt.

Also, the README.me mentioned older Ubuntu versions that are listed in metadata.json