### PR TITLE
(misc) Delete choria::version hiera entries

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,2 +1,0 @@
----
-choria::version: "0.29.4+%{facts.os.distro.codename}"

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,2 +1,0 @@
----
-choria::version: "0.29.4"


### PR DESCRIPTION
Previously, Debian and Redhat OS families had their own choria version set in Hiera. The old versions aren't available anymore on the repo.

The default is already `present`, so I don't think it makes sense to pin to a specific version.

```
$ git grep choria::version
README.md:choria::version: 0.0.7-1.el%{facts.os.release.major}
data/common.yaml:choria::version: "present"
manifests/install.pp:      "present" => $choria::version,
```