### PR TITLE
(misc) Debian/RedHat: Update choria 0.29.4->0.30.0

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,2 @@
+---
+choria::version: "0.30.0+generic"

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,2 @@
+---
+choria::version: "0.30.0"


### PR DESCRIPTION
This pins the two OS families to latest choria 0.30.0. After a mirror rework, the older version isn't available anymore.

Fixes e5031c0b68c74514f3b34139615baa72e1ba8800